### PR TITLE
Allow datamill client to perform PATCH requests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,6 +121,11 @@
             <version>1.16.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.7.3</version>

--- a/core/src/main/java/org/chodavarapu/datamill/http/Client.java
+++ b/core/src/main/java/org/chodavarapu/datamill/http/Client.java
@@ -127,27 +127,28 @@ public class Client {
         }, Schedulers.io());
     }
 
-    private CloseableHttpResponse doWithEntity(Entity entity, CloseableHttpClient httpclient, HttpUriRequest request) throws IOException {
+    private CloseableHttpResponse doWithEntity(Entity entity, CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
         if (!(request instanceof HttpEntityEnclosingRequestBase)) {
             throw new IllegalArgumentException("Expecting to write an entity for a request type that does not support it!");
         }
-        try (PipedOutputStream pipedOutputStream = buildPipedOutputStream();
-             PipedInputStream pipedInputStream = buildPipedInputStream()) {
-            pipedInputStream.connect(pipedOutputStream);
 
-            BasicHttpEntity httpEntity = new BasicHttpEntity();
-            httpEntity.setContent(pipedInputStream);
-            ((HttpEntityEnclosingRequestBase) request).setEntity(httpEntity);
+        PipedOutputStream pipedOutputStream = buildPipedOutputStream();
+        PipedInputStream pipedInputStream = buildPipedInputStream();
 
-            writeEntityOutOverConnection(entity, pipedOutputStream);
+        pipedInputStream.connect(pipedOutputStream);
 
-            return doExecute(httpclient, request);
-        }
+        BasicHttpEntity httpEntity = new BasicHttpEntity();
+        httpEntity.setContent(pipedInputStream);
+        ((HttpEntityEnclosingRequestBase) request).setEntity(httpEntity);
+
+        writeEntityOutOverConnection(entity, pipedOutputStream);
+
+        return doExecute(httpClient, request);
     }
 
 
-    protected CloseableHttpResponse doExecute(CloseableHttpClient httpclient, HttpUriRequest request) throws IOException {
-        return httpclient.execute(request);
+    protected CloseableHttpResponse doExecute(CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
+        return httpClient.execute(request);
     }
 
     private void printRequestIfDebugging(Method method, URI composedUri, Multimap<String, String> headers) {

--- a/core/src/main/java/org/chodavarapu/datamill/http/Method.java
+++ b/core/src/main/java/org/chodavarapu/datamill/http/Method.java
@@ -7,7 +7,7 @@ import java.util.Set;
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public enum Method {
-    OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, PATCH, UNKNOWN;
+    OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, PATCH, UNKNOWN;
 
     private static final Set<Method> methods =
             EnumSet.allOf(Method.class);

--- a/core/src/main/java/org/chodavarapu/datamill/http/impl/InputStreamEntity.java
+++ b/core/src/main/java/org/chodavarapu/datamill/http/impl/InputStreamEntity.java
@@ -4,6 +4,7 @@ import org.chodavarapu.datamill.http.Entity;
 import org.chodavarapu.datamill.http.HttpException;
 import org.chodavarapu.datamill.json.JsonObject;
 import rx.Observable;
+import rx.functions.Action0;
 import rx.observables.StringObservable;
 
 import java.io.ByteArrayOutputStream;
@@ -15,9 +16,15 @@ import java.io.InputStream;
  */
 public class InputStreamEntity implements Entity {
     private final InputStream inputStream;
+    private final Action0 completionHandler;
 
     public InputStreamEntity(InputStream inputStream) {
+        this(inputStream, null);
+    }
+
+    public InputStreamEntity(InputStream inputStream, Action0 completionHandler) {
         this.inputStream = inputStream;
+        this.completionHandler = completionHandler;
     }
 
     @Override
@@ -40,7 +47,8 @@ public class InputStreamEntity implements Entity {
 
     @Override
     public Observable<byte[]> asChunks() {
-        return StringObservable.from(inputStream);
+        return StringObservable.from(inputStream)
+                .doAfterTerminate(completionHandler != null ? completionHandler : () -> {});
     }
 
     @Override

--- a/core/src/test/java/org/chodavarapu/datamill/http/ClientTest.java
+++ b/core/src/test/java/org/chodavarapu/datamill/http/ClientTest.java
@@ -1,8 +1,10 @@
 package org.chodavarapu.datamill.http;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.*;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -223,11 +225,16 @@ public class ClientTest {
         }
 
         @Override
-        protected CloseableHttpResponse doExecute(CloseableHttpClient httpclient, HttpUriRequest request) throws IOException {
+        protected CloseableHttpResponse doExecute(CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
             CloseableHttpResponse response = mock(CloseableHttpResponse.class);
             when(response.getAllHeaders()).thenReturn(new Header[0]);
             when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
             when(response.getEntity()).thenReturn(mock(HttpEntity.class));
+
+            if (request instanceof HttpEntityEnclosingRequest) {
+                ByteStreams.toByteArray(((HttpEntityEnclosingRequest) request).getEntity().getContent());
+            }
+
             return response;
         }
 

--- a/core/src/test/java/org/chodavarapu/datamill/http/ClientTest.java
+++ b/core/src/test/java/org/chodavarapu/datamill/http/ClientTest.java
@@ -1,22 +1,32 @@
 package org.chodavarapu.datamill.http;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.chodavarapu.datamill.http.impl.ValueEntity;
 import org.chodavarapu.datamill.values.StringValue;
 import org.junit.Test;
 import rx.Observable;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URLConnection;
+import java.io.PipedOutputStream;
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
@@ -24,19 +34,20 @@ import static org.mockito.Mockito.*;
 public class ClientTest {
     private void verifyConnectionSetup(TestClient client, Method method, String uri, Map<String, String> headers, String entity)
             throws Exception {
-        assertEquals(uri, client.getLastUri());
-        verify(client.getMockConnection(), times(1)).setRequestMethod(method.name());
+        HttpUriRequest request = client.getRequest();
+
+        assertThat(request.getURI().toString(), equalTo(uri));
+        assertThat(request.getMethod(), equalTo(method.name()));
 
         if (headers != null) {
             for (Map.Entry<String, String> header : headers.entrySet()) {
-                verify(client.getMockConnection(), times(1)).addRequestProperty(header.getKey(), header.getValue());
+                verify(request, times(1)).addHeader(header.getKey(), header.getValue());
             }
-        } else {
-            verify(client.getMockConnection(), times(0)).addRequestProperty(anyString(), anyString());
         }
 
         if (entity != null) {
-            assertEquals(entity, client.getLastOutputValue());
+            byte[] testAsBytes = entity.getBytes();
+            verify(client.getSpiedPipedOutputStream()).write(testAsBytes, 0, testAsBytes.length);
         }
     }
 
@@ -201,31 +212,24 @@ public class ClientTest {
 
     private class TestClient extends Client {
         private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        private String uri;
-        private HttpURLConnection mockConnection;
         private Semaphore entitySent = new Semaphore(0);
 
+        private PipedOutputStream spiedPipedOutputStream;
+
+        private HttpUriRequest request;
+
         public TestClient() {
-            mockConnection = mock(HttpURLConnection.class);
-            try {
-                when(mockConnection.getOutputStream()).thenReturn(outputStream);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+        }
+
+
+        PipedOutputStream getSpiedPipedOutputStream() {
+            return spiedPipedOutputStream;
         }
 
         @Override
-        protected URLConnection createConnection(String uri) throws IOException {
-            this.uri = uri;
-            return mockConnection;
-        }
-
-        public String getLastUri() {
-            return uri;
-        }
-
-        public HttpURLConnection getMockConnection() {
-            return mockConnection;
+        protected PipedOutputStream buildPipedOutputStream() {
+            this.spiedPipedOutputStream =  spy(PipedOutputStream.class);
+            return this.spiedPipedOutputStream;
         }
 
         @Override
@@ -233,9 +237,46 @@ public class ClientTest {
             entitySent.release();
         }
 
-        public String getLastOutputValue() {
-            entitySent.acquireUninterruptibly();
-            return new String(outputStream.toByteArray());
+        public HttpUriRequest getRequest() {
+            return request;
+        }
+
+        protected HttpUriRequest buildHttpRequest(Method method, URI uri) {
+            switch (method) {
+                case OPTIONS:
+                    HttpOptions httpOptions = new HttpOptions(uri);
+                    this.request = spy(httpOptions);
+                    return request;
+                case GET:
+                    HttpGet httpGet = new HttpGet(uri);
+                    this.request = spy(httpGet);
+                    return request;
+                case HEAD:
+                    HttpHead httpHead = new HttpHead(uri);
+                    this.request = spy(httpHead);
+                    return request;
+                case POST:
+                    HttpPost httpPost = new HttpPost(uri);
+                    this.request = spy(httpPost);
+                    return request;
+                case PUT:
+                    HttpPut httpPut = new HttpPut(uri);
+                    this.request = spy(httpPut);
+                    return request;
+                case DELETE:
+                    HttpDelete httpDelete = new HttpDelete(uri);
+                    this.request = spy(httpDelete);
+                    return request;
+                case TRACE:
+                    HttpTrace httpTrace = new HttpTrace(uri);
+                    this.request = spy(httpTrace);
+                    return request;
+                case PATCH:
+                    HttpPatch httpPatch = new HttpPatch(uri);
+                    this.request = spy(httpPatch);
+                    return request;
+                default: throw new IllegalArgumentException("Method " + method + " is not implemented!");
+            }
         }
     }
 }

--- a/core/src/test/java/org/chodavarapu/datamill/http/ClientTest.java
+++ b/core/src/test/java/org/chodavarapu/datamill/http/ClientTest.java
@@ -1,32 +1,26 @@
 package org.chodavarapu.datamill.http;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.*;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
 import org.chodavarapu.datamill.http.impl.ValueEntity;
 import org.chodavarapu.datamill.values.StringValue;
 import org.junit.Test;
 import rx.Observable;
 
-import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PipedOutputStream;
 import java.net.URI;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
 import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
@@ -211,11 +205,7 @@ public class ClientTest {
     }
 
     private class TestClient extends Client {
-        private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        private Semaphore entitySent = new Semaphore(0);
-
         private PipedOutputStream spiedPipedOutputStream;
-
         private HttpUriRequest request;
 
         public TestClient() {
@@ -233,8 +223,12 @@ public class ClientTest {
         }
 
         @Override
-        protected void onEntitySendingCompletion(Entity entity) {
-            entitySent.release();
+        protected CloseableHttpResponse doExecute(CloseableHttpClient httpclient, HttpUriRequest request) throws IOException {
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+            when(response.getAllHeaders()).thenReturn(new Header[0]);
+            when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
+            when(response.getEntity()).thenReturn(mock(HttpEntity.class));
+            return response;
         }
 
         public HttpUriRequest getRequest() {

--- a/core/src/test/java/org/chodavarapu/datamill/http/impl/RequestBuilderImplTest.java
+++ b/core/src/test/java/org/chodavarapu/datamill/http/impl/RequestBuilderImplTest.java
@@ -55,14 +55,12 @@ public class RequestBuilderImplTest {
 
     @Test
     public void methods() {
-        assertEquals(Method.CONNECT, new RequestBuilderImpl().method("CONNECT").build().method());
         assertEquals(Method.GET, new RequestBuilderImpl().method("GET").build().method());
         assertEquals(Method.HEAD, new RequestBuilderImpl().method("HEAD").build().method());
         assertEquals(Method.POST, new RequestBuilderImpl().method("POST").build().method());
         assertEquals(Method.PUT, new RequestBuilderImpl().method("PUT").build().method());
         assertEquals(Method.DELETE, new RequestBuilderImpl().method("DELETE").build().method());
         assertEquals(Method.TRACE, new RequestBuilderImpl().method("TRACE").build().method());
-        assertEquals(Method.CONNECT, new RequestBuilderImpl().method("CONNECT").build().method());
         assertEquals(Method.PATCH, new RequestBuilderImpl().method("PATCH").build().method());
     }
 }


### PR DESCRIPTION
Reimplemented client request core method to rely on httpclient rather than JDK UrlConnection, as the latter doesn't allow certain Http methods (i.e. PATCH).
Adapted tests to new implementation.