### PR TITLE
A few additional cucumber steps, and special placeholders to use in step values

### DIFF
--- a/cucumber/src/main/java/org/chodavarapu/datamill/cucumber/HttpSteps.java
+++ b/cucumber/src/main/java/org/chodavarapu/datamill/cucumber/HttpSteps.java
@@ -103,6 +103,16 @@ public class HttpSteps {
         assertFalse(Strings.isNullOrEmpty(responseEntity));
     }
 
+    @Then("^" + Phrases.SUBJECT + " should get a (\\d+) response with " + Phrases.HTTP_BODY + " containing \"(.+)\"$")
+    public void assertStatusAndResponseWithContent(int statusCode, String expectedContent) {
+        assertStatus(statusCode);
+
+        String responseEntity = (String) propertyStore.get(LAST_RESPONSE_BODY_KEY);
+
+        String resolvedExpectedContent = placeholderResolver.resolve(expectedContent);
+        assertTrue(responseEntity.contains(resolvedExpectedContent));
+    }
+
     @Then("^" + Phrases.SUBJECT + " should get a (\\d+) response$")
     public void assertStatus(int statusCode) {
         Response storedResponse = (Response) propertyStore.get(RESPONSE_KEY);

--- a/cucumber/src/main/java/org/chodavarapu/datamill/cucumber/HttpSteps.java
+++ b/cucumber/src/main/java/org/chodavarapu/datamill/cucumber/HttpSteps.java
@@ -158,6 +158,12 @@ public class HttpSteps {
         headers.put(headerKey, placeholderResolver.resolve(value));
     }
 
+    @And("^the request header (.+) is removed$")
+    public void removeHeader(String header) {
+        Map<String, String> headers = initAndGetHeaders();
+        headers.remove(header);
+    }
+
     public Status getLastResponseStatus() {
         Response storedResponse = (Response) propertyStore.get(RESPONSE_KEY);
         return storedResponse.status();

--- a/cucumber/src/main/java/org/chodavarapu/datamill/cucumber/PropertySteps.java
+++ b/cucumber/src/main/java/org/chodavarapu/datamill/cucumber/PropertySteps.java
@@ -14,11 +14,13 @@ import static org.junit.Assert.fail;
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public class PropertySteps {
+    private final PlaceholderResolver placeholderResolver;
     private final PropertyStore propertyStore;
     private final HtmlLinkExtractor linkExtractor = new HtmlLinkExtractor();
 
-    public PropertySteps(PropertyStore propertyStore) {
+    public PropertySteps(PropertyStore propertyStore, PlaceholderResolver placeholderResolver) {
         this.propertyStore = propertyStore;
+        this.placeholderResolver = placeholderResolver;
     }
 
 
@@ -66,7 +68,8 @@ public class PropertySteps {
     @Given("^" + Phrases.SUBJECT + " store" + Phrases.OPTIONAL_PLURAL + " (.+) as " +
             Phrases.PROPERTY_KEY + "$")
     public void storeProperty(String value, String key) {
-        propertyStore.put(key, value);
+        String resolvedValue = placeholderResolver.resolve(value);
+        propertyStore.put(key, resolvedValue);
     }
 
     @Given("^" + Phrases.SUBJECT + " hash(?:es)? (.+) (?:using Blowfish |using BCrypt )?and stores it as " +

--- a/cucumber/src/test/java/org/chodavarapu/datamill/cucumber/HttpStepsTest.java
+++ b/cucumber/src/test/java/org/chodavarapu/datamill/cucumber/HttpStepsTest.java
@@ -25,6 +25,7 @@ import static org.chodavarapu.datamill.cucumber.HttpSteps.LAST_RESPONSE_BODY_KEY
 import static org.chodavarapu.datamill.cucumber.HttpSteps.RESPONSE_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 
 
 /**
@@ -147,6 +148,19 @@ public class HttpStepsTest {
         httpSteps.addValueToHeader(STORE_KEY, HEADER_VALUE);
 
         assertThat(((Map<String, String>) propertyStore.get(HEADER_KEY)).get(STORE_KEY), is(HEADER_VALUE));
+    }
+
+    @Test
+    public void removeHeader_worksAsExpected() {
+        prepareResponse(Status.OK, EXPECTED_JSON);
+
+        final String inputJson = "{ \"input\" : \"json\"}";
+        httpSteps.userMakesCallWithProvidedPayload(Method.POST, String.format(URI, serverPort, "test/post"), inputJson);
+
+        httpSteps.addValueToHeader(STORE_KEY, HEADER_VALUE);
+        httpSteps.removeHeader(STORE_KEY);
+
+        assertNull(((Map<String, String>) propertyStore.get(HEADER_KEY)).get(STORE_KEY));
     }
 
     @Test

--- a/cucumber/src/test/java/org/chodavarapu/datamill/cucumber/PlaceholderResolverTest.java
+++ b/cucumber/src/test/java/org/chodavarapu/datamill/cucumber/PlaceholderResolverTest.java
@@ -15,6 +15,7 @@ public class PlaceholderResolverTest {
         PropertyStore store = new PropertyStore();
         store.put("property1", "value1");
         store.put("prop2", "value2");
+        store.put("base64Prop", "user:pass");
         store.put("json", "{\"name\": \"test\", \"count\": 3}");
 
         PlaceholderResolver resolver = new PlaceholderResolver(store);
@@ -31,5 +32,8 @@ public class PlaceholderResolverTest {
         assertEquals("Hello world!", resolver.resolve("Hello world!"));
         assertEquals(33, resolver.resolve("H{randomAlphanumeric32}").length());
         assertTrue(BCrypt.checkpw("pass", resolver.resolve("{blowfish:pass}")));
+        assertTrue(BCrypt.checkpw("value2", resolver.resolve("{blowfish:prop2}")));
+        assertEquals("dXNlcjpwYXNz", resolver.resolve("{base64:user:pass}"));
+        assertEquals("dXNlcjpwYXNz", resolver.resolve("{base64:base64Prop}"));
     }
 }

--- a/cucumber/src/test/java/org/chodavarapu/datamill/cucumber/PropertyStepsTest.java
+++ b/cucumber/src/test/java/org/chodavarapu/datamill/cucumber/PropertyStepsTest.java
@@ -12,13 +12,15 @@ import static org.junit.Assert.assertTrue;
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public class PropertyStepsTest {
+    private PlaceholderResolver resolver;
     private PropertyStore store;
     private PropertySteps steps;
 
     @Before
     public void setUp() {
         store = new PropertyStore();
-        steps = new PropertySteps(store);
+        resolver = new PlaceholderResolver(store);
+        steps = new PropertySteps(store, resolver);
     }
 
     @Test
@@ -51,5 +53,8 @@ public class PropertyStepsTest {
         assertEquals("value", store.get("test"));
         steps.removeProperty("test");
         assertNull(store.get("test"));
+        store.put("property1", "value1");
+        steps.storeProperty("{property1}", "test2");
+        assertEquals("value1", store.get("test2"));
     }
 }


### PR DESCRIPTION
- Step to assert response containing strings
- Add additional HTTP step to remove a header
- Add special placeholders to base64 encode values
- Allow property references in hashed and base64 placeholders
- Allow property to be stored which has placeholders in its value