### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/foundation/stack/datamill/configuration/SystemPropertyRetriever.java
+++ b/core/src/main/java/foundation/stack/datamill/configuration/SystemPropertyRetriever.java
@@ -5,6 +5,9 @@ package foundation.stack.datamill.configuration;
  */
 public class SystemPropertyRetriever {
 
+    private SystemPropertyRetriever() {
+    }
+
     public static String getSystemProperty(String name, boolean required) {
         String value = System.getProperty(name);
 

--- a/core/src/main/java/foundation/stack/datamill/http/impl/ServerRequestBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/ServerRequestBuilder.java
@@ -15,6 +15,9 @@ import java.util.concurrent.ExecutorService;
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public class ServerRequestBuilder {
+    private ServerRequestBuilder() {
+    }
+
     public static ServerRequestImpl buildServerRequest(HttpRequest request, Observable<byte[]> entityStream, ExecutorService threadPool) {
         Charset messageCharset = HttpUtil.getCharset(request);
         return new ServerRequestImpl(

--- a/core/src/main/java/foundation/stack/datamill/security/KeyGenerators.java
+++ b/core/src/main/java/foundation/stack/datamill/security/KeyGenerators.java
@@ -9,6 +9,9 @@ import org.jose4j.lang.ByteUtil;
  */
 public interface KeyGenerators {
     class Symmetric {
+        private Symmetric() {
+        }
+
         public static void main(String[] arguments) throws Exception {
             byte[] bytes = ByteUtil.randomBytes(ByteUtil.byteLength(512));
             OctetSequenceJsonWebKey key = new OctetSequenceJsonWebKey(new HmacKey(bytes));
@@ -18,6 +21,9 @@ public interface KeyGenerators {
     }
 
     class RSA {
+        private RSA() {
+        }
+
         public static void main(String[] arguments) throws Exception {
             RsaJsonWebKey key = RsaJwkGenerator.generateJwk(2048);
             key.setKeyId("k" + System.currentTimeMillis());

--- a/core/src/main/java/foundation/stack/datamill/values/Times.java
+++ b/core/src/main/java/foundation/stack/datamill/values/Times.java
@@ -7,6 +7,9 @@ import java.time.temporal.Temporal;
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public class Times {
+    private Times() {
+    }
+
     public static long toEpochMillis(Temporal temporal) {
         if (temporal instanceof LocalDate) {
             return ((LocalDate) temporal).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/FuzzyJsonTester.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/FuzzyJsonTester.java
@@ -14,6 +14,9 @@ public class FuzzyJsonTester {
     private static final String ANY_VALUE = "*";
     private static final Logger logger = LoggerFactory.getLogger(FuzzyJsonTester.class);
 
+    private FuzzyJsonTester() {
+    }
+
     private static boolean areJsonObjectsSimilarEnough(JsonObject expected, JsonObject actual) {
         if (!actual.propertyNames().containsAll(expected.propertyNames())) {
             return false;

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/RandomGenerator.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/RandomGenerator.java
@@ -12,6 +12,9 @@ public class RandomGenerator {
             'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_'};
 
+    private RandomGenerator() {
+    }
+
     public static String generateRandomAlphanumeric(int length) {
         StringBuilder name = new StringBuilder("n");
         for (int i = 0; i < length - 2; i++) {

--- a/cucumber/src/test/java/foundation/stack/datamill/cucumber/TestUtil.java
+++ b/cucumber/src/test/java/foundation/stack/datamill/cucumber/TestUtil.java
@@ -8,6 +8,9 @@ import java.net.ServerSocket;
  */
 public class TestUtil {
 
+    private TestUtil() {
+    }
+
     public static Integer findRandomPort(int defaultPort)  {
         try {
             try (ServerSocket socket = new ServerSocket(0)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.