### PR TITLE
Fix: squid:S1155, Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/core/src/main/java/foundation/stack/datamill/db/impl/QueryBuilderImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/db/impl/QueryBuilderImpl.java
@@ -224,7 +224,7 @@ public abstract class QueryBuilderImpl implements QueryBuilder {
 
         @Override
         public UpdateQueryExecution onDuplicateKeyUpdate(Map<String, ?> values) {
-            if (values.size() > 0) {
+            if (!values.isEmpty()) {
                 query.append(SQL_ON_DUPLICATE_KEY_UPDATE);
                 appendUpdateAssignments(query, parameters, values);
             }
@@ -281,7 +281,7 @@ public abstract class QueryBuilderImpl implements QueryBuilder {
 
         @Override
         public Observable<Row> all() {
-            if (parameters.size() > 0) {
+            if (!parameters.isEmpty()) {
                 return QueryBuilderImpl.this.query(query.toString(), parameters.toArray(new Object[parameters.size()]));
             } else {
                 return QueryBuilderImpl.this.query(query.toString());

--- a/core/src/main/java/foundation/stack/datamill/http/Client.java
+++ b/core/src/main/java/foundation/stack/datamill/http/Client.java
@@ -74,7 +74,7 @@ public class Client {
             Map<String, ?> options,
             Entity entity) {
 
-        if (uriParameters != null && uriParameters.size() > 0) {
+        if (uriParameters != null && !uriParameters.isEmpty()) {
             uri = templateBasedUriBuilder.build(uri, uriParameters);
         }
 
@@ -190,7 +190,7 @@ public class Client {
     }
 
     private void setRequestOptions(HttpUriRequest request, Map<String, ?> options) {
-        if (options != null && options.size() > 0) {
+        if (options != null && !options.isEmpty()) {
             Object connectTimeout = options.get(Request.OPTION_CONNECT_TIMEOUT);
             if (connectTimeout instanceof Integer) {
                 RequestConfig requestConfig = RequestConfig.custom()
@@ -233,7 +233,7 @@ public class Client {
     }
 
     private URI appendQueryParameters(URIBuilder uriBuilder, Multimap<String, String> queryParameters) throws URISyntaxException {
-        if (queryParameters != null && queryParameters.size() > 0) {
+        if (queryParameters != null && !queryParameters.isEmpty()) {
             queryParameters.entries().stream().forEach(entry -> {
                 try {
                     uriBuilder.setParameter(URLEncoder.encode(entry.getKey(), "UTF-8"), entry.getValue());

--- a/core/src/main/java/foundation/stack/datamill/http/impl/AbstractRequestImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/AbstractRequestImpl.java
@@ -18,7 +18,7 @@ public abstract class AbstractRequestImpl implements Request {
     protected static Value firstValue(Multimap<String, String> entries, String name) {
         if (entries != null) {
             Collection<String> values = entries.get(name);
-            if (values.size() > 0) {
+            if (!values.isEmpty()) {
                 return new StringValue(values.iterator().next());
             }
         }

--- a/core/src/main/java/foundation/stack/datamill/http/impl/BeanMethodMatcher.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/BeanMethodMatcher.java
@@ -125,7 +125,7 @@ public class BeanMethodMatcher implements Matcher {
             }
         }
 
-        if (methods.size() > 0) {
+        if (!methods.isEmpty()) {
             return methods;
         }
 

--- a/core/src/main/java/foundation/stack/datamill/http/impl/ClientToServerChannelHandler.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/ClientToServerChannelHandler.java
@@ -152,7 +152,7 @@ public class ClientToServerChannelHandler extends ChannelInboundHandlerAdapter {
             response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, contentLength);
         }
 
-        if (headers != null && headers.size() > 0) {
+        if (headers != null && !headers.isEmpty()) {
             for (Map.Entry<String, String> header : headers.entries()) {
                 response.headers().add(header.getKey(), header.getValue());
             }

--- a/core/src/main/java/foundation/stack/datamill/http/impl/MatcherBasedRoute.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/MatcherBasedRoute.java
@@ -46,7 +46,7 @@ public class MatcherBasedRoute implements PostProcessedRoute {
                 }
             }
 
-            if (availableMethods.size() > 0) {
+            if (!availableMethods.isEmpty()) {
                 return request.respond(b ->
                         b.header("Access-Control-Allow-Methods", Joiner.on(',').join(availableMethods))
                         .ok())

--- a/core/src/main/java/foundation/stack/datamill/reflection/impl/OutlineImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/reflection/impl/OutlineImpl.java
@@ -151,7 +151,7 @@ public class OutlineImpl<T> implements Outline<T> {
     private static Method OBJECT_GET_CLASS_METHOD;
 
     private static String capitalize(String string) {
-        if (string != null && string.length() > 0) {
+        if (string != null && !string.isEmpty()) {
             return Character.toUpperCase(string.charAt(0)) + string.substring(1);
         }
 

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/CommandLineSteps.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/CommandLineSteps.java
@@ -186,7 +186,7 @@ public class CommandLineSteps {
                         resolvedFile.exists());
             }
         } else {
-            if (names.size() > 0) {
+            if (!names.isEmpty()) {
                 fail("A temporary directory was not created to verify the existence of any files!");
             }
         }

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/PropertySteps.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/PropertySteps.java
@@ -29,7 +29,7 @@ public class PropertySteps {
         String html = (String) propertyStore.get(htmlKey);
         List<HtmlLinkExtractor.HtmlLink> links = linkExtractor.extractLinks(html);
 
-        if (links.size() > 0) {
+        if (!links.isEmpty()) {
             propertyStore.put(propertyKey, links.get(0).getLinkTarget());
         } else {
             fail("Could not find any links in stored HTML!");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155

 Please let me know if you have any questions.
Ayman Elkfrawy.