### PR TITLE
Fix: squid:S1149, Synchronized classes Vector, Hashtable, Stack and S…

### DIFF
--- a/core/src/main/java/foundation/stack/datamill/security/impl/BCrypt.java
+++ b/core/src/main/java/foundation/stack/datamill/security/impl/BCrypt.java
@@ -389,7 +389,7 @@ public class BCrypt {
 	private static String encode_base64(byte d[], int len)
 		throws IllegalArgumentException {
 		int off = 0;
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 		int c1, c2;
 
 		if (len <= 0 || len > d.length)
@@ -442,7 +442,7 @@ public class BCrypt {
 	 */
 	private static byte[] decode_base64(String s, int maxolen)
 		throws IllegalArgumentException {
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 		int off = 0, slen = s.length(), olen = 0;
 		byte ret[];
 		byte c1, c2, c3, c4, o;
@@ -655,7 +655,7 @@ public class BCrypt {
 		byte passwordb[], saltb[], hashed[];
 		char minor = (char)0;
 		int rounds, off = 0;
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 
 		if (salt.charAt(0) != '$' || salt.charAt(1) != '2')
 			throw new IllegalArgumentException ("Invalid salt version");
@@ -713,7 +713,7 @@ public class BCrypt {
 	 * @return	an encoded salt value
 	 */
 	public static String gensalt(int log_rounds, SecureRandom random) {
-		StringBuffer rs = new StringBuffer();
+		StringBuilder rs = new StringBuilder();
 		byte rnd[] = new byte[BCRYPT_SALT_LEN];
 
 		random.nextBytes(rnd);

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/HtmlLinkExtractor.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/HtmlLinkExtractor.java
@@ -1,5 +1,6 @@
 package foundation.stack.datamill.cucumber;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 import java.util.regex.Matcher;
@@ -25,7 +26,7 @@ public class HtmlLinkExtractor {
 
     public List<HtmlLink> extractLinks(final String html) {
 
-        Vector<HtmlLink> result = new Vector<HtmlLink>();
+        List<HtmlLink> result = new ArrayList<>();
 
         matcherTag = patternTag.matcher(html);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 

 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Ayman Elkfrawy.