### PR TITLE
Default non-streaming queries

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP-java6</artifactId>
+            <artifactId>HikariCP</artifactId>
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,5 +111,10 @@
             <artifactId>jackson-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/foundation/stack/datamill/db/DatabaseClient.java
+++ b/core/src/main/java/foundation/stack/datamill/db/DatabaseClient.java
@@ -4,6 +4,7 @@ import com.github.davidmoten.rx.jdbc.*;
 import foundation.stack.datamill.configuration.Named;
 import foundation.stack.datamill.db.impl.QueryBuilderImpl;
 import foundation.stack.datamill.db.impl.RowImpl;
+import foundation.stack.datamill.db.impl.UnsubscribeOnCompletedOperator;
 import org.flywaydb.core.Flyway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,8 +203,8 @@ public class DatabaseClient extends QueryBuilderImpl implements QueryRunner {
         }
 
         @Override
-        public <T> Observable<T> getFirstAs(Func1<Row, T> transformer) {
-            return stream().map(transformer).first();
+        public <T> Observable<T> firstAs(Func1<Row, T> transformer) {
+            return stream().map(transformer).take(1).lift(new UnsubscribeOnCompletedOperator<>());
         }
 
         @Override

--- a/core/src/main/java/foundation/stack/datamill/db/DatabaseClient.java
+++ b/core/src/main/java/foundation/stack/datamill/db/DatabaseClient.java
@@ -4,7 +4,7 @@ import com.github.davidmoten.rx.jdbc.*;
 import foundation.stack.datamill.configuration.Named;
 import foundation.stack.datamill.db.impl.QueryBuilderImpl;
 import foundation.stack.datamill.db.impl.RowImpl;
-import foundation.stack.datamill.db.impl.UnsubscribeOnCompletedOperator;
+import foundation.stack.datamill.db.impl.UnsubscribeOnNextOperator;
 import org.flywaydb.core.Flyway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -204,7 +204,7 @@ public class DatabaseClient extends QueryBuilderImpl implements QueryRunner {
 
         @Override
         public <T> Observable<T> firstAs(Func1<Row, T> transformer) {
-            return stream().map(transformer).take(1).lift(new UnsubscribeOnCompletedOperator<>());
+            return stream().map(transformer).take(1).lift(new UnsubscribeOnNextOperator<>());
         }
 
         @Override

--- a/core/src/main/java/foundation/stack/datamill/db/LimitBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/LimitBuilder.java
@@ -1,4 +1,4 @@
-package foundation.stack.datamill;
+package foundation.stack.datamill.db;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)

--- a/core/src/main/java/foundation/stack/datamill/db/QueryBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/QueryBuilder.java
@@ -1,6 +1,5 @@
 package foundation.stack.datamill.db;
 
-import foundation.stack.datamill.LimitBuilder;
 import foundation.stack.datamill.reflection.Outline;
 
 /**

--- a/core/src/main/java/foundation/stack/datamill/db/QueryRunner.java
+++ b/core/src/main/java/foundation/stack/datamill/db/QueryRunner.java
@@ -1,12 +1,10 @@
 package foundation.stack.datamill.db;
 
-import rx.Observable;
-
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public interface QueryRunner {
-    Observable<Row> query(String sql);
-    Observable<Row> query(String sql, Object... parameters);
+    ResultBuilder query(String sql);
+    ResultBuilder query(String sql, Object... parameters);
     UpdateQueryExecution update(String sql, Object... parameters);
 }

--- a/core/src/main/java/foundation/stack/datamill/db/ResultBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/ResultBuilder.java
@@ -10,6 +10,6 @@ import java.util.List;
  */
 public interface ResultBuilder {
     <T> Observable<List<T>> getAs(Func1<Row, T> transformer);
-    <T> Observable<T> getFirstAs(Func1<Row, T> transformer);
+    <T> Observable<T> firstAs(Func1<Row, T> transformer);
     Observable<Row> stream();
 }

--- a/core/src/main/java/foundation/stack/datamill/db/ResultBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/ResultBuilder.java
@@ -1,0 +1,15 @@
+package foundation.stack.datamill.db;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+import java.util.List;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public interface ResultBuilder {
+    <T> Observable<List<T>> getAs(Func1<Row, T> transformer);
+    <T> Observable<T> getFirstAs(Func1<Row, T> transformer);
+    Observable<Row> stream();
+}

--- a/core/src/main/java/foundation/stack/datamill/db/SelectBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/SelectBuilder.java
@@ -1,12 +1,11 @@
 package foundation.stack.datamill.db;
 
 import foundation.stack.datamill.reflection.Outline;
-import rx.Observable;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public interface SelectBuilder {
-    SelectWhereBuilder<Observable<Row>> from(String table);
-    SelectWhereBuilder<Observable<Row>> from(Outline<?> outline);
+    SelectWhereBuilder<ResultBuilder> from(String table);
+    SelectWhereBuilder<ResultBuilder> from(Outline<?> outline);
 }

--- a/core/src/main/java/foundation/stack/datamill/db/SelectLimitBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/SelectLimitBuilder.java
@@ -1,6 +1,5 @@
 package foundation.stack.datamill.db;
 
-import foundation.stack.datamill.LimitBuilder;
 import foundation.stack.datamill.reflection.Member;
 
 /**

--- a/core/src/main/java/foundation/stack/datamill/db/UpdateBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/UpdateBuilder.java
@@ -1,7 +1,5 @@
 package foundation.stack.datamill.db;
 
-import foundation.stack.datamill.LimitBuilder;
-
 import java.util.Map;
 import java.util.function.Function;
 

--- a/core/src/main/java/foundation/stack/datamill/db/WhereBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/db/WhereBuilder.java
@@ -1,6 +1,5 @@
 package foundation.stack.datamill.db;
 
-import foundation.stack.datamill.LimitBuilder;
 import foundation.stack.datamill.reflection.Outline;
 import rx.functions.Func1;
 

--- a/core/src/main/java/foundation/stack/datamill/db/impl/QueryBuilderImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/db/impl/QueryBuilderImpl.java
@@ -1,7 +1,7 @@
 package foundation.stack.datamill.db.impl;
 
 import com.google.common.base.Joiner;
-import foundation.stack.datamill.LimitBuilder;
+import foundation.stack.datamill.db.LimitBuilder;
 import foundation.stack.datamill.db.*;
 import foundation.stack.datamill.reflection.Member;
 import foundation.stack.datamill.reflection.Outline;
@@ -219,13 +219,13 @@ public abstract class QueryBuilderImpl implements QueryBuilder {
         }
     }
 
-    private class SelectWhereClause extends WhereBuilderImpl<Observable<Row>> {
+    private class SelectWhereClause extends WhereBuilderImpl<ResultBuilder> {
         public SelectWhereClause(StringBuilder query) {
             super(query);
         }
 
         @Override
-        public Observable<Row> execute() {
+        public ResultBuilder execute() {
             if (!parameters.isEmpty()) {
                 return QueryBuilderImpl.this.query(query.toString(), parameters.toArray(new Object[parameters.size()]));
             } else {
@@ -248,14 +248,14 @@ public abstract class QueryBuilderImpl implements QueryBuilder {
         }
 
         @Override
-        public SelectWhereBuilder<Observable<Row>> from(String table) {
+        public SelectWhereBuilder<ResultBuilder> from(String table) {
             query.append(SqlSyntax.SQL_FROM);
             query.append(table);
             return new SelectWhereClause(query);
         }
 
         @Override
-        public SelectWhereBuilder<Observable<Row>> from(Outline<?> outline) {
+        public SelectWhereBuilder<ResultBuilder> from(Outline<?> outline) {
             return from(outline.pluralName());
         }
     }
@@ -295,8 +295,8 @@ public abstract class QueryBuilderImpl implements QueryBuilder {
         return insertInto(outline.pluralName());
     }
 
-    protected abstract Observable<Row> query(String query);
-    protected abstract Observable<Row> query(String query, Object... parameters);
+    protected abstract ResultBuilder query(String query);
+    protected abstract ResultBuilder query(String query, Object... parameters);
     protected abstract UpdateQueryExecution update(String query, Object... parameters);
 
     @Override

--- a/core/src/main/java/foundation/stack/datamill/db/impl/UnsubscribeOnCompletedOperator.java
+++ b/core/src/main/java/foundation/stack/datamill/db/impl/UnsubscribeOnCompletedOperator.java
@@ -1,0 +1,58 @@
+package foundation.stack.datamill.db.impl;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.exceptions.Exceptions;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public class UnsubscribeOnCompletedOperator<T> implements Observable.Operator<T, T> {
+    private final AtomicBoolean completed = new AtomicBoolean();
+
+    @Override
+    public Subscriber<? super T> call(Subscriber<? super T> subscriber) {
+        return new Subscriber<T>() {
+            @Override
+            public void onCompleted() {
+                this.unsubscribe();
+
+                if (!subscriber.isUnsubscribed()) {
+                    if (completed.compareAndSet(false, true)) {
+                        subscriber.onCompleted();
+                    }
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                this.unsubscribe();
+
+                if (!subscriber.isUnsubscribed()) {
+                    if (completed.compareAndSet(false, true)) {
+                        subscriber.onError(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onNext(T t) {
+                this.unsubscribe();
+
+                if (!subscriber.isUnsubscribed()) {
+                    if (completed.compareAndSet(false, true)) {
+                        try {
+                            subscriber.onNext(t);
+                            subscriber.onCompleted();
+                        } catch (Throwable e) {
+                            Exceptions.throwIfFatal(e);
+                            subscriber.onError(e);
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/core/src/main/java/foundation/stack/datamill/db/impl/UnsubscribeOnNextOperator.java
+++ b/core/src/main/java/foundation/stack/datamill/db/impl/UnsubscribeOnNextOperator.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
-public class UnsubscribeOnCompletedOperator<T> implements Observable.Operator<T, T> {
+public class UnsubscribeOnNextOperator<T> implements Observable.Operator<T, T> {
     private final AtomicBoolean completed = new AtomicBoolean();
 
     @Override

--- a/core/src/main/java/foundation/stack/datamill/db/test/TestDatabaseClient.java
+++ b/core/src/main/java/foundation/stack/datamill/db/test/TestDatabaseClient.java
@@ -4,7 +4,7 @@ import foundation.stack.datamill.db.DatabaseClient;
 import foundation.stack.datamill.db.ResultBuilder;
 import foundation.stack.datamill.db.Row;
 import foundation.stack.datamill.db.UpdateQueryExecution;
-import foundation.stack.datamill.db.impl.UnsubscribeOnCompletedOperator;
+import foundation.stack.datamill.db.impl.UnsubscribeOnNextOperator;
 import rx.Observable;
 import rx.functions.Func1;
 
@@ -59,7 +59,7 @@ public class TestDatabaseClient extends DatabaseClient {
 
             @Override
             public <T> Observable<T> firstAs(Func1<Row, T> transformer) {
-                return stream().map(transformer).take(1).lift(new UnsubscribeOnCompletedOperator<>());
+                return stream().map(transformer).take(1).lift(new UnsubscribeOnNextOperator<>());
             }
 
             @Override

--- a/core/src/main/java/foundation/stack/datamill/db/test/TestDatabaseClient.java
+++ b/core/src/main/java/foundation/stack/datamill/db/test/TestDatabaseClient.java
@@ -4,6 +4,7 @@ import foundation.stack.datamill.db.DatabaseClient;
 import foundation.stack.datamill.db.ResultBuilder;
 import foundation.stack.datamill.db.Row;
 import foundation.stack.datamill.db.UpdateQueryExecution;
+import foundation.stack.datamill.db.impl.UnsubscribeOnCompletedOperator;
 import rx.Observable;
 import rx.functions.Func1;
 
@@ -57,8 +58,8 @@ public class TestDatabaseClient extends DatabaseClient {
             }
 
             @Override
-            public <T> Observable<T> getFirstAs(Func1<Row, T> transformer) {
-                return stream().map(transformer).first();
+            public <T> Observable<T> firstAs(Func1<Row, T> transformer) {
+                return stream().map(transformer).take(1).lift(new UnsubscribeOnCompletedOperator<>());
             }
 
             @Override

--- a/core/src/test/java/foundation/stack/datamill/db/impl/DatabaseClientTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/impl/DatabaseClientTest.java
@@ -1,0 +1,77 @@
+package foundation.stack.datamill.db.impl;
+
+import foundation.stack.datamill.db.DatabaseClient;
+import foundation.stack.datamill.reflection.Outline;
+import foundation.stack.datamill.reflection.OutlineBuilder;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public class DatabaseClientTest {
+    private static class Quark {
+        private String name;
+        private int spin;
+
+        public String getName() {
+            return name;
+        }
+
+        public Quark setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public int getSpin() {
+            return spin;
+        }
+
+        public Quark setSpin(int spin) {
+            this.spin = spin;
+            return this;
+        }
+    }
+
+    @Test
+    public void queries() {
+        DatabaseClient client = new DatabaseClient("jdbc:hsqldb:mem:test");
+        Outline<Quark> outline = new OutlineBuilder().build(Quark.class);
+
+        client.update("create table quarks(name varchar(64), spin integer)", 0)
+                .count()
+                .toBlocking()
+                .last();
+
+        client.insertInto(outline).row(rb -> rb
+                .put(outline.member(m -> m.getName()), "up")
+                .put(outline.member(m -> m.getSpin()), 1)
+                .build())
+                .count()
+                .toBlocking()
+                .last();
+
+        List<Quark> quarks = client.selectAll().from(outline).all().getAs(r -> outline.wrap(new Quark())
+                .set(p -> p.getName(), r.column(outline.member(m -> m.getName())))
+                .set(p -> p.getSpin(), r.column(outline.member(m -> m.getSpin())))
+                .unwrap())
+                .toBlocking().last();
+
+        assertEquals(1, quarks.size());
+        assertEquals("up", quarks.get(0).getName());
+        assertEquals(1, quarks.get(0).getSpin());
+
+        Quark quark = client.selectAll().from(outline).all().firstAs(r -> outline.wrap(new Quark())
+                .set(p -> p.getName(), r.column(outline.member(m -> m.getName())))
+                .set(p -> p.getSpin(), r.column(outline.member(m -> m.getSpin())))
+                .unwrap())
+                .toBlocking().last();
+
+        assertEquals(1, quarks.size());
+        assertEquals("up", quarks.get(0).getName());
+        assertEquals(1, quarks.get(0).getSpin());
+    }
+}

--- a/core/src/test/java/foundation/stack/datamill/db/impl/QueryBuilderImplTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/impl/QueryBuilderImplTest.java
@@ -2,7 +2,6 @@ package foundation.stack.datamill.db.impl;
 
 import com.google.common.collect.ImmutableMap;
 import foundation.stack.datamill.db.ResultBuilder;
-import foundation.stack.datamill.db.Row;
 import foundation.stack.datamill.db.UpdateQueryExecution;
 import foundation.stack.datamill.reflection.Outline;
 import foundation.stack.datamill.reflection.OutlineBuilder;

--- a/core/src/test/java/foundation/stack/datamill/db/impl/QueryBuilderImplTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/impl/QueryBuilderImplTest.java
@@ -1,6 +1,7 @@
 package foundation.stack.datamill.db.impl;
 
 import com.google.common.collect.ImmutableMap;
+import foundation.stack.datamill.db.ResultBuilder;
 import foundation.stack.datamill.db.Row;
 import foundation.stack.datamill.db.UpdateQueryExecution;
 import foundation.stack.datamill.reflection.Outline;
@@ -77,7 +78,7 @@ public class QueryBuilderImplTest {
         }
 
         @Override
-        protected Observable<Row> query(String query) {
+        protected ResultBuilder query(String query) {
             lastQuery = query;
             lastWasUpdate = false;
             lastParameters = new Object[0];
@@ -85,7 +86,7 @@ public class QueryBuilderImplTest {
         }
 
         @Override
-        protected Observable<Row> query(String query, Object... parameters) {
+        protected ResultBuilder query(String query, Object... parameters) {
             lastQuery = query;
             lastParameters = parameters;
             lastWasUpdate = false;

--- a/core/src/test/java/foundation/stack/datamill/db/impl/UnsubscribeOnCompletedOperatorTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/impl/UnsubscribeOnCompletedOperatorTest.java
@@ -1,0 +1,24 @@
+package foundation.stack.datamill.db.impl;
+
+import org.junit.Test;
+import rx.Observable;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public class UnsubscribeOnCompletedOperatorTest {
+    @Test
+    public void operator() {
+        int[] unsubscribed = new int[] { 1 };
+        int result = Observable.just(1, 2, 3)
+                .doOnUnsubscribe(() -> unsubscribed[0] = unsubscribed[0] + 10)
+                .lift(new UnsubscribeOnCompletedOperator<>())
+                .doOnUnsubscribe(() -> unsubscribed[0] = unsubscribed[0] * 2)
+                .toBlocking()
+                .lastOrDefault(0);
+        assertEquals(1, result);
+        assertEquals(22, unsubscribed[0]);
+    }
+}

--- a/core/src/test/java/foundation/stack/datamill/db/impl/UnsubscribeOnNextOperatorTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/impl/UnsubscribeOnNextOperatorTest.java
@@ -8,13 +8,13 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
-public class UnsubscribeOnCompletedOperatorTest {
+public class UnsubscribeOnNextOperatorTest {
     @Test
     public void operator() {
         int[] unsubscribed = new int[] { 1 };
         int result = Observable.just(1, 2, 3)
                 .doOnUnsubscribe(() -> unsubscribed[0] = unsubscribed[0] + 10)
-                .lift(new UnsubscribeOnCompletedOperator<>())
+                .lift(new UnsubscribeOnNextOperator<>())
                 .doOnUnsubscribe(() -> unsubscribed[0] = unsubscribed[0] * 2)
                 .toBlocking()
                 .lastOrDefault(0);

--- a/core/src/test/java/foundation/stack/datamill/db/test/TestDatabaseClientTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/test/TestDatabaseClientTest.java
@@ -90,7 +90,7 @@ public class TestDatabaseClientTest {
         client.select(testModelOutline.member(m -> m.getProperty()))
                 .from(testModelOutline)
                 .all()
-                .getFirstAs(row -> testModelOutline.wrap(new TestModel())
+                .firstAs(row -> testModelOutline.wrap(new TestModel())
                         .set(m -> m.getProperty(), row.column(testModelOutline.member(m -> m.getProperty())))
                         .set(m -> m.getStringProperty(), row.column(testModelOutline.member(m -> m.getStringProperty())))
                         .unwrap())

--- a/core/src/test/java/foundation/stack/datamill/db/test/TestDatabaseClientTest.java
+++ b/core/src/test/java/foundation/stack/datamill/db/test/TestDatabaseClientTest.java
@@ -64,7 +64,7 @@ public class TestDatabaseClientTest {
         client.changeCatalog("catalog");
         verify(database).changeCatalog("catalog");
 
-        client.query("SELECT * FROM table");
+        client.query("SELECT * FROM table").stream();
         verify(database).query("SELECT * FROM table", new Object[0]);
 
         client.update("UPDATE table SET column = NULL", new Object[0]).count();
@@ -90,7 +90,7 @@ public class TestDatabaseClientTest {
         client.select(testModelOutline.member(m -> m.getProperty()))
                 .from(testModelOutline)
                 .all()
-                .map(row -> testModelOutline.wrap(new TestModel())
+                .getFirstAs(row -> testModelOutline.wrap(new TestModel())
                         .set(m -> m.getProperty(), row.column(testModelOutline.member(m -> m.getProperty())))
                         .set(m -> m.getStringProperty(), row.column(testModelOutline.member(m -> m.getStringProperty())))
                         .unwrap())

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/DatabaseSteps.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/DatabaseSteps.java
@@ -69,7 +69,7 @@ public class DatabaseSteps {
     }
 
     private Observable<Row> executeSelect(String resolvedUrl, String sql, Object... parameters) {
-        return new DatabaseClient(resolvedUrl).query(sql, parameters);
+        return new DatabaseClient(resolvedUrl).query(sql, parameters).stream();
     }
 
     protected String buildQuery(String tableName, String testFragment, String criteriaFragment) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,8 +105,8 @@
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP-java6</artifactId>
-                <version>2.3.2</version>
+                <artifactId>HikariCP</artifactId>
+                <version>2.5.1</version>
             </dependency>
             <dependency>
                 <groupId>io.reactivex</groupId>


### PR DESCRIPTION
Change queries to ones that encourage quickly transforming results so that connections can be closed
 Allow a "streaming" version of queries to use the old style of streaming rows directly