### PR TITLE
Support for creating APIs based on AWS Lambda-backed API Gateway proxies, other improvements

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -61,10 +62,6 @@
             <artifactId>HikariCP</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.reactivex</groupId>
-            <artifactId>rxjava-string</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.atteo</groupId>
             <artifactId>evo-inflector</artifactId>
         </dependency>
@@ -97,6 +94,10 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -109,10 +110,7 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>
@@ -120,4 +118,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,6 +45,14 @@
             <artifactId>netty-codec-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.davidmoten</groupId>
             <artifactId>rxjava-jdbc</artifactId>
         </dependency>
@@ -105,11 +113,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>

--- a/core/src/main/java/foundation/stack/datamill/http/Body.java
+++ b/core/src/main/java/foundation/stack/datamill/http/Body.java
@@ -29,4 +29,12 @@ public interface Body {
 
     /** Get an {@link Observable} that emits the whole body as a single string. */
     Observable<String> asString();
+
+    /**
+     * Deserialize (using Jackson) the body as an object.
+     * @param clazz Class to deserialize as.
+     * @param <T> Type of object to deserialize.
+     * @return An observable that emits the body as an object of the desired type.
+     */
+    <T> Observable<T> fromJson(Class<T> clazz);
 }

--- a/core/src/main/java/foundation/stack/datamill/http/Client.java
+++ b/core/src/main/java/foundation/stack/datamill/http/Client.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.schedulers.Schedulers;
-import rx.util.async.Async;
 
 import java.io.IOException;
 import java.io.PipedInputStream;
@@ -88,15 +87,14 @@ public class Client {
 
         final URI targetURI = parsedURI;
 
-        return Async.fromCallable(() -> {
+        return Observable.fromCallable(() -> {
             CloseableHttpClient httpClient = HttpClients.createDefault();
             HttpUriRequest request = buildHttpRequest(method, targetURI);
             setRequestOptions(request, options);
             setRequestHeaders(request, headers);
             printRequestIfDebugging(method, targetURI, headers);
 
-            CloseableHttpResponse httpResponse = null;
-
+            CloseableHttpResponse httpResponse;
             if (body != null) {
                 httpResponse = doWithEntity(body, httpClient, request);
             } else {
@@ -109,7 +107,7 @@ public class Client {
             int responseCode = finalResponse.getStatusLine().getStatusCode();
             return new ResponseImpl(Status.valueOf(responseCode), combinedHeaders,
                     buildResponseEntity(finalResponse, httpClient));
-        }, Schedulers.io());
+        });
     }
 
     private Body buildResponseEntity(CloseableHttpResponse finalResponse, CloseableHttpClient httpClient) throws IOException {

--- a/core/src/main/java/foundation/stack/datamill/http/Client.java
+++ b/core/src/main/java/foundation/stack/datamill/http/Client.java
@@ -1,358 +1,70 @@
 package foundation.stack.datamill.http;
 
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import foundation.stack.datamill.http.impl.InputStreamBody;
-import foundation.stack.datamill.http.impl.ValueBody;
-import org.apache.http.Header;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import foundation.stack.datamill.http.impl.EmptyBody;
-import foundation.stack.datamill.http.impl.RequestBuilderImpl;
-import foundation.stack.datamill.http.impl.ResponseImpl;
-import foundation.stack.datamill.http.impl.TemplateBasedUriBuilder;
 import foundation.stack.datamill.values.Value;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import rx.Observable;
-import rx.schedulers.Schedulers;
 
-import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
-public class Client {
-    private static final Logger logger = LoggerFactory.getLogger(Client.class);
-    private final TemplateBasedUriBuilder templateBasedUriBuilder = new TemplateBasedUriBuilder();
+public interface Client {
+    Observable<Response> request(Function<RequestBuilder, Request> builder);
 
-    public Observable<Response> request(Function<RequestBuilder, Request> builder) {
-        Request request = builder.apply(new RequestBuilderImpl());
-        return request(request.method(), request.headers(), request.uri(), request.uriParameters(),
-                request.queryParameters(), request.options(), request.body());
-    }
+    Observable<Response> request(Method method, Map<String, String> headers, String uri, Value entity);
 
-    public Observable<Response> request(Method method, Map<String, String> headers, String uri, Value entity) {
-        return request(method, headers, uri, new ValueBody(entity));
-    }
+    Observable<Response> request(Method method, Map<String, String> headers, String uri, Body body);
 
-    public Observable<Response> request(Method method, Map<String, String> headers, String uri, Body body) {
-        return request(method, headers != null ? Multimaps.forMap(headers) : null, uri, null, null, null, body);
-    }
-
-    public Observable<Response> request(
+    Observable<Response> request(
             Method method,
             Multimap<String, String> headers,
             String uri,
             Map<String, String> uriParameters,
             Multimap<String, String> queryParameters,
             Map<String, ?> options,
-            Body body) {
+            Body body);
 
-        if (uriParameters != null && !uriParameters.isEmpty()) {
-            uri = templateBasedUriBuilder.build(uri, uriParameters);
-        }
+    Observable<Response> delete(String uri);
 
-        URI parsedURI;
-        try {
-            URIBuilder uriBuilder = new URIBuilder(uri);
-            parsedURI = appendQueryParameters(uriBuilder, queryParameters);
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Could not build URI for " + uri);
-        }
+    Observable<Response> delete(String uri, Map<String, String> headers);
 
-        final URI targetURI = parsedURI;
+    Observable<Response> delete(Function<RequestBuilder, Request> builder);
 
-        return Observable.fromCallable(() -> {
-            CloseableHttpClient httpClient = HttpClients.createDefault();
-            HttpUriRequest request = buildHttpRequest(method, targetURI);
-            setRequestOptions(request, options);
-            setRequestHeaders(request, headers);
-            printRequestIfDebugging(method, targetURI, headers);
+    Observable<Response> get(String uri);
 
-            CloseableHttpResponse httpResponse;
-            if (body != null) {
-                httpResponse = doWithEntity(body, httpClient, request);
-            } else {
-                httpResponse = doExecute(httpClient, request);
-            }
+    Observable<Response> get(String uri, Map<String, String> headers);
 
-            CloseableHttpResponse finalResponse = httpResponse;
+    Observable<Response> get(Function<RequestBuilder, Request> builder);
 
-            Map<String, String> combinedHeaders = populateResponseHeaders(finalResponse);
-            int responseCode = finalResponse.getStatusLine().getStatusCode();
-            return new ResponseImpl(Status.valueOf(responseCode), combinedHeaders,
-                    buildResponseEntity(finalResponse, httpClient));
-        });
-    }
+    Observable<Response> patch(String uri, Body body);
 
-    private Body buildResponseEntity(CloseableHttpResponse finalResponse, CloseableHttpClient httpClient) throws IOException {
-        if (finalResponse != null && finalResponse.getEntity() != null) {
-            return new InputStreamBody(finalResponse.getEntity().getContent(), () -> {
-                try {
-                    finalResponse.close();
-                } catch (IOException e) {
-                    logger.debug("Error while closing response stream!", e);
-                }
+    Observable<Response> patch(String uri, Value entity);
 
-                if (httpClient != null) {
-                    try {
-                        httpClient.close();
-                    } catch (IOException e) {
-                        logger.debug("Error while closing client!", e);
-                    }
-                }
-            });
-        }
-        else {
-            return new EmptyBody();
-        }
-    }
+    Observable<Response> patch(String uri, Map<String, String> headers, Body body);
 
-    private CloseableHttpResponse doWithEntity(Body body, CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
-        if (!(request instanceof HttpEntityEnclosingRequestBase)) {
-            throw new IllegalArgumentException("Expecting to write an body for a request type that does not support it!");
-        }
+    Observable<Response> patch(String uri, Map<String, String> headers, Value entity);
 
-        PipedOutputStream pipedOutputStream = buildPipedOutputStream();
-        PipedInputStream pipedInputStream = buildPipedInputStream();
+    Observable<Response> patch(Function<RequestBuilder, Request> builder);
 
-        pipedInputStream.connect(pipedOutputStream);
+    Observable<Response> post(String uri, Body body);
 
-        BasicHttpEntity httpEntity = new BasicHttpEntity();
-        httpEntity.setContent(pipedInputStream);
-        ((HttpEntityEnclosingRequestBase) request).setEntity(httpEntity);
+    Observable<Response> post(String uri, Value entity);
 
-        writeEntityOutOverConnection(body, pipedOutputStream);
+    Observable<Response> post(String uri, Map<String, String> headers, Body body);
 
-        return doExecute(httpClient, request);
-    }
+    Observable<Response> post(String uri, Map<String, String> headers, Value entity);
 
+    Observable<Response> post(Function<RequestBuilder, Request> builder);
 
-    protected CloseableHttpResponse doExecute(CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
-        return httpClient.execute(request);
-    }
+    Observable<Response> put(String uri, Body body);
 
-    private void printRequestIfDebugging(Method method, URI composedUri, Multimap<String, String> headers) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Making HTTP request {} {}", method.name(), composedUri);
-            if (headers != null && logger.isDebugEnabled()) {
-                logger.debug("  HTTP request headers:");
-                for (Map.Entry<String, String> header : headers.entries()) {
-                    logger.debug("    {}: {}", header.getKey(), header.getValue());
-                }
-            }
-        }
-    }
+    Observable<Response> put(String uri, Value entity);
 
-    private Map<String, String> populateResponseHeaders(CloseableHttpResponse httpResponse) {
-        Map<String, String> combinedHeaders = new HashMap<>();
+    Observable<Response> put(String uri, Map<String, String> headers, Body body);
 
-        for (Header header : httpResponse.getAllHeaders()) {
-            combinedHeaders.put(header.getName(), header.getValue());
-        }
+    Observable<Response> put(String uri, Map<String, String> headers, Value entity);
 
-        return combinedHeaders;
-    }
-
-    private void setRequestHeaders(HttpUriRequest request, Multimap<String, String> headers) {
-        if (headers != null) {
-            for (Map.Entry<String, String> header : headers.entries()) {
-                request.addHeader(header.getKey().toLowerCase(), header.getValue());
-            }
-        }
-    }
-
-    private void setRequestOptions(HttpUriRequest request, Map<String, ?> options) {
-        if (options != null && !options.isEmpty()) {
-            Object connectTimeout = options.get(Request.OPTION_CONNECT_TIMEOUT);
-            if (connectTimeout instanceof Integer) {
-                RequestConfig requestConfig = RequestConfig.custom()
-                        .setConnectTimeout((int) connectTimeout)
-                        .build();
-                ((HttpRequestBase) request).setConfig(requestConfig);
-            }
-        }
-    }
-
-    protected PipedOutputStream buildPipedOutputStream() {
-        return new PipedOutputStream();
-    }
-
-    protected PipedInputStream buildPipedInputStream() {
-        return new PipedInputStream();
-    }
-
-    protected HttpUriRequest buildHttpRequest(Method method, URI uri) {
-        switch (method) {
-            case OPTIONS:
-                return new HttpOptions(uri);
-            case GET:
-                return new HttpGet(uri);
-            case HEAD:
-                return new HttpHead(uri);
-            case POST:
-                return new HttpPost(uri);
-            case PUT:
-                return new HttpPut(uri);
-            case DELETE:
-                return new HttpDelete(uri);
-            case TRACE:
-                return new HttpTrace(uri);
-            case PATCH:
-                return new HttpPatch(uri);
-            default:
-                throw new IllegalArgumentException("Method " + method + " is not implemented!");
-        }
-    }
-
-    private URI appendQueryParameters(URIBuilder uriBuilder, Multimap<String, String> queryParameters) throws URISyntaxException {
-        if (queryParameters != null && !queryParameters.isEmpty()) {
-            queryParameters.entries().stream().forEach(entry -> {
-                try {
-                    uriBuilder.setParameter(URLEncoder.encode(entry.getKey(), "UTF-8"), entry.getValue());
-                } catch (UnsupportedEncodingException e) {
-                }
-            });
-        }
-        return uriBuilder.build();
-    }
-
-    private void writeEntityOutOverConnection(Body body, PipedOutputStream pipedOutputStream) throws IOException {
-        body.asChunks().observeOn(Schedulers.io())
-                .doOnNext(bytes -> {
-                    try {
-                        pipedOutputStream.write(bytes);
-                    } catch (IOException e) {
-                        throw new HttpException("Error writing body!", e);
-                    }
-                })
-                .doOnCompleted(() -> {
-                    try {
-                        pipedOutputStream.close();
-                    } catch (IOException e) {
-                        throw new HttpException("Error while closing stream!", e);
-                    }
-                })
-                .doOnError(e -> {
-                    try {
-                        pipedOutputStream.close();
-                    } catch (IOException closing) {
-                        throw new HttpException("Error while closing stream due to an original exception!", e);
-                    }
-
-                    throw new HttpException(e);
-                })
-                .subscribe();
-    }
-
-    public Observable<Response> delete(String uri) {
-        return delete(uri, null);
-    }
-
-    public Observable<Response> delete(String uri, Map<String, String> headers) {
-        return request(Method.DELETE, headers, uri, (Body) null);
-    }
-
-
-    public Observable<Response> delete(Function<RequestBuilder, Request> builder) {
-        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.DELETE)));
-    }
-
-    public Observable<Response> get(String uri) {
-        return get(uri, null);
-    }
-
-    public Observable<Response> get(String uri, Map<String, String> headers) {
-        return request(Method.GET, headers, uri, (Body) null);
-    }
-
-
-    public Observable<Response> get(Function<RequestBuilder, Request> builder) {
-        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.GET)));
-    }
-
-    public Observable<Response> patch(String uri, Body body) {
-        return patch(uri, null, body);
-    }
-
-    public Observable<Response> patch(String uri, Value entity) {
-        return patch(uri, null, entity);
-    }
-
-    public Observable<Response> patch(String uri, Map<String, String> headers, Body body) {
-        return request(Method.PATCH, headers, uri, body);
-    }
-
-    public Observable<Response> patch(String uri, Map<String, String> headers, Value entity) {
-        return request(Method.PATCH, headers, uri, entity);
-    }
-
-    public Observable<Response> patch(Function<RequestBuilder, Request> builder) {
-        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.PATCH)));
-    }
-
-    public Observable<Response> post(String uri, Body body) {
-        return post(uri, null, body);
-    }
-
-    public Observable<Response> post(String uri, Value entity) {
-        return post(uri, null, entity);
-    }
-
-    public Observable<Response> post(String uri, Map<String, String> headers, Body body) {
-        return request(Method.POST, headers, uri, body);
-    }
-
-    public Observable<Response> post(String uri, Map<String, String> headers, Value entity) {
-        return request(Method.POST, headers, uri, entity);
-    }
-
-    public Observable<Response> post(Function<RequestBuilder, Request> builder) {
-        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.POST)));
-    }
-
-    public Observable<Response> put(String uri, Body body) {
-        return put(uri, null, body);
-    }
-
-    public Observable<Response> put(String uri, Value entity) {
-        return put(uri, null, entity);
-    }
-
-    public Observable<Response> put(String uri, Map<String, String> headers, Body body) {
-        return request(Method.PUT, headers, uri, body);
-    }
-
-    public Observable<Response> put(String uri, Map<String, String> headers, Value entity) {
-        return request(Method.PUT, headers, uri, entity);
-    }
-
-    public Observable<Response> put(Function<RequestBuilder, Request> builder) {
-        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.PUT)));
-    }
+    Observable<Response> put(Function<RequestBuilder, Request> builder);
 }

--- a/core/src/main/java/foundation/stack/datamill/http/ResponseBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/http/ResponseBuilder.java
@@ -45,6 +45,15 @@ public interface ResponseBuilder {
     /** Build a response with a 200 OK status, and the given byte array body. */
     Response ok(byte[] content);
 
+    /** Build a response with a specific status, and an empty body. */
+    Response status(Status status);
+
+    /** Build a response with a specific status, and the given string body. */
+    Response status(Status status, String content);
+
+    /** Build a response with a specific status, and the given byte array body. */
+    Response status(Status status, byte[] content);
+
     /**
      * Add a body to the response being built which is made up of byte buffer data emissions. The lambda will receive a
      * {@link Observer} on which it can call {@link Observer#onNext(Object)} to emit data as byte buffers. These

--- a/core/src/main/java/foundation/stack/datamill/http/builder/ElseBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/http/builder/ElseBuilder.java
@@ -17,6 +17,7 @@ public interface ElseBuilder {
     ElseBuilder elseIfMethodMatches(foundation.stack.datamill.http.Method method, Route route);
     ElseBuilder elseIfUriMatches(String pattern, Route route);
     ElseBuilder elseIfMethodAndUriMatch(foundation.stack.datamill.http.Method method, String pattern, Route route);
+    <T> ElseBuilder elseIfMatchesBeanMethod(T bean);
     ElseBuilder elseIfMatchesBeanMethod(Bean<?> bean);
     ElseBuilder elseIfMatchesBeanMethod(
             Bean<?> bean,

--- a/core/src/main/java/foundation/stack/datamill/http/builder/RouteBuilder.java
+++ b/core/src/main/java/foundation/stack/datamill/http/builder/RouteBuilder.java
@@ -16,6 +16,7 @@ public interface RouteBuilder {
     ElseBuilder ifUriMatches(String pattern, Route route);
     ElseBuilder ifMethodMatches(Method method, Route route);
     ElseBuilder ifMethodAndUriMatch(Method method, String pattern, Route route);
+    <T> ElseBuilder ifMatchesBeanMethod(T bean);
     ElseBuilder ifMatchesBeanMethod(Bean<?> bean);
     ElseBuilder ifMatchesBeanMethod(
             Bean<?> bean,

--- a/core/src/main/java/foundation/stack/datamill/http/impl/AbstractBody.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/AbstractBody.java
@@ -1,17 +1,26 @@
 package foundation.stack.datamill.http.impl;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Lists;
 import foundation.stack.datamill.http.Body;
 import foundation.stack.datamill.json.JsonObject;
 import org.json.JSONArray;
 import rx.Observable;
+import rx.exceptions.Exceptions;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
 public abstract class AbstractBody implements Body {
+    private static final ObjectMapper jsonMapper = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+
     @Override
     public Observable<JsonObject> asJsonArray() {
         return asString().flatMap(json -> {
@@ -21,6 +30,17 @@ public abstract class AbstractBody implements Body {
                 jsonObjects.add(new JsonObject(array.get(i).toString()));
             }
             return Observable.from(jsonObjects);
+        });
+    }
+
+    @Override
+    public <T> Observable<T> fromJson(Class<T> clazz) {
+        return asString().map(json -> {
+            try {
+                return jsonMapper.readValue(json, clazz);
+            } catch (IOException e) {
+                throw Exceptions.propagate(e);
+            }
         });
     }
 }

--- a/core/src/main/java/foundation/stack/datamill/http/impl/AbstractRequestImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/AbstractRequestImpl.java
@@ -1,5 +1,6 @@
 package foundation.stack.datamill.http.impl;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import foundation.stack.datamill.http.Body;
 import foundation.stack.datamill.http.Method;
@@ -34,7 +35,7 @@ public abstract class AbstractRequestImpl implements Request {
 
     protected AbstractRequestImpl(String method, Multimap<String, String> headers, String uri, Body body) {
         this.method = method;
-        this.headers = headers;
+        this.headers = headers != null ? headers : ArrayListMultimap.create();
         this.uri = uri;
         this.body = body;
     }

--- a/core/src/main/java/foundation/stack/datamill/http/impl/ClientImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/ClientImpl.java
@@ -1,0 +1,378 @@
+package foundation.stack.datamill.http.impl;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import foundation.stack.datamill.http.*;
+import org.apache.http.Header;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import foundation.stack.datamill.values.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.schedulers.Schedulers;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public class ClientImpl implements Client {
+    private static final Logger logger = LoggerFactory.getLogger(ClientImpl.class);
+    private final TemplateBasedUriBuilder templateBasedUriBuilder = new TemplateBasedUriBuilder();
+
+    @Override
+    public Observable<Response> request(Function<RequestBuilder, Request> builder) {
+        Request request = builder.apply(new RequestBuilderImpl());
+        return request(request.method(), request.headers(), request.uri(), request.uriParameters(),
+                request.queryParameters(), request.options(), request.body());
+    }
+
+    @Override
+    public Observable<Response> request(Method method, Map<String, String> headers, String uri, Value entity) {
+        return request(method, headers, uri, new ValueBody(entity));
+    }
+
+    @Override
+    public Observable<Response> request(Method method, Map<String, String> headers, String uri, Body body) {
+        return request(method, headers != null ? Multimaps.forMap(headers) : null, uri, null, null, null, body);
+    }
+
+    @Override
+    public Observable<Response> request(
+            Method method,
+            Multimap<String, String> headers,
+            String uri,
+            Map<String, String> uriParameters,
+            Multimap<String, String> queryParameters,
+            Map<String, ?> options,
+            Body body) {
+
+        if (uriParameters != null && !uriParameters.isEmpty()) {
+            uri = templateBasedUriBuilder.build(uri, uriParameters);
+        }
+
+        URI parsedURI;
+        try {
+            URIBuilder uriBuilder = new URIBuilder(uri);
+            parsedURI = appendQueryParameters(uriBuilder, queryParameters);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Could not build URI for " + uri);
+        }
+
+        final URI targetURI = parsedURI;
+
+        return Observable.fromCallable(() -> {
+            CloseableHttpClient httpClient = HttpClients.createDefault();
+            HttpUriRequest request = buildHttpRequest(method, targetURI);
+            setRequestOptions(request, options);
+            setRequestHeaders(request, headers);
+            printRequestIfDebugging(method, targetURI, headers);
+
+            CloseableHttpResponse httpResponse;
+            if (body != null) {
+                httpResponse = doWithEntity(body, httpClient, request);
+            } else {
+                httpResponse = doExecute(httpClient, request);
+            }
+
+            CloseableHttpResponse finalResponse = httpResponse;
+
+            Map<String, String> combinedHeaders = populateResponseHeaders(finalResponse);
+            int responseCode = finalResponse.getStatusLine().getStatusCode();
+            return new ResponseImpl(Status.valueOf(responseCode), combinedHeaders,
+                    buildResponseEntity(finalResponse, httpClient));
+        });
+    }
+
+    private Body buildResponseEntity(CloseableHttpResponse finalResponse, CloseableHttpClient httpClient) throws IOException {
+        if (finalResponse != null && finalResponse.getEntity() != null) {
+            return new InputStreamBody(finalResponse.getEntity().getContent(), () -> {
+                try {
+                    finalResponse.close();
+                } catch (IOException e) {
+                    logger.debug("Error while closing response stream!", e);
+                }
+
+                if (httpClient != null) {
+                    try {
+                        httpClient.close();
+                    } catch (IOException e) {
+                        logger.debug("Error while closing client!", e);
+                    }
+                }
+            });
+        }
+        else {
+            return new EmptyBody();
+        }
+    }
+
+    private CloseableHttpResponse doWithEntity(Body body, CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
+        if (!(request instanceof HttpEntityEnclosingRequestBase)) {
+            throw new IllegalArgumentException("Expecting to write an body for a request type that does not support it!");
+        }
+
+        PipedOutputStream pipedOutputStream = buildPipedOutputStream();
+        PipedInputStream pipedInputStream = buildPipedInputStream();
+
+        pipedInputStream.connect(pipedOutputStream);
+
+        BasicHttpEntity httpEntity = new BasicHttpEntity();
+        httpEntity.setContent(pipedInputStream);
+        ((HttpEntityEnclosingRequestBase) request).setEntity(httpEntity);
+
+        writeEntityOutOverConnection(body, pipedOutputStream);
+
+        return doExecute(httpClient, request);
+    }
+
+
+    protected CloseableHttpResponse doExecute(CloseableHttpClient httpClient, HttpUriRequest request) throws IOException {
+        return httpClient.execute(request);
+    }
+
+    private void printRequestIfDebugging(Method method, URI composedUri, Multimap<String, String> headers) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Making HTTP request {} {}", method.name(), composedUri);
+            if (headers != null && logger.isDebugEnabled()) {
+                logger.debug("  HTTP request headers:");
+                for (Map.Entry<String, String> header : headers.entries()) {
+                    logger.debug("    {}: {}", header.getKey(), header.getValue());
+                }
+            }
+        }
+    }
+
+    private Map<String, String> populateResponseHeaders(CloseableHttpResponse httpResponse) {
+        Map<String, String> combinedHeaders = new HashMap<>();
+
+        for (Header header : httpResponse.getAllHeaders()) {
+            combinedHeaders.put(header.getName(), header.getValue());
+        }
+
+        return combinedHeaders;
+    }
+
+    private void setRequestHeaders(HttpUriRequest request, Multimap<String, String> headers) {
+        if (headers != null) {
+            for (Map.Entry<String, String> header : headers.entries()) {
+                request.addHeader(header.getKey().toLowerCase(), header.getValue());
+            }
+        }
+    }
+
+    private void setRequestOptions(HttpUriRequest request, Map<String, ?> options) {
+        if (options != null && !options.isEmpty()) {
+            Object connectTimeout = options.get(Request.OPTION_CONNECT_TIMEOUT);
+            if (connectTimeout instanceof Integer) {
+                RequestConfig requestConfig = RequestConfig.custom()
+                        .setConnectTimeout((int) connectTimeout)
+                        .build();
+                ((HttpRequestBase) request).setConfig(requestConfig);
+            }
+        }
+    }
+
+    protected PipedOutputStream buildPipedOutputStream() {
+        return new PipedOutputStream();
+    }
+
+    protected PipedInputStream buildPipedInputStream() {
+        return new PipedInputStream();
+    }
+
+    protected HttpUriRequest buildHttpRequest(Method method, URI uri) {
+        switch (method) {
+            case OPTIONS:
+                return new HttpOptions(uri);
+            case GET:
+                return new HttpGet(uri);
+            case HEAD:
+                return new HttpHead(uri);
+            case POST:
+                return new HttpPost(uri);
+            case PUT:
+                return new HttpPut(uri);
+            case DELETE:
+                return new HttpDelete(uri);
+            case TRACE:
+                return new HttpTrace(uri);
+            case PATCH:
+                return new HttpPatch(uri);
+            default:
+                throw new IllegalArgumentException("Method " + method + " is not implemented!");
+        }
+    }
+
+    private URI appendQueryParameters(URIBuilder uriBuilder, Multimap<String, String> queryParameters) throws URISyntaxException {
+        if (queryParameters != null && !queryParameters.isEmpty()) {
+            queryParameters.entries().stream().forEach(entry -> {
+                try {
+                    uriBuilder.setParameter(URLEncoder.encode(entry.getKey(), "UTF-8"), entry.getValue());
+                } catch (UnsupportedEncodingException e) {
+                }
+            });
+        }
+        return uriBuilder.build();
+    }
+
+    private void writeEntityOutOverConnection(Body body, PipedOutputStream pipedOutputStream) throws IOException {
+        body.asChunks().observeOn(Schedulers.io())
+                .doOnNext(bytes -> {
+                    try {
+                        pipedOutputStream.write(bytes);
+                    } catch (IOException e) {
+                        throw new HttpException("Error writing body!", e);
+                    }
+                })
+                .doOnCompleted(() -> {
+                    try {
+                        pipedOutputStream.close();
+                    } catch (IOException e) {
+                        throw new HttpException("Error while closing stream!", e);
+                    }
+                })
+                .doOnError(e -> {
+                    try {
+                        pipedOutputStream.close();
+                    } catch (IOException closing) {
+                        throw new HttpException("Error while closing stream due to an original exception!", e);
+                    }
+
+                    throw new HttpException(e);
+                })
+                .subscribe();
+    }
+
+    @Override
+    public Observable<Response> delete(String uri) {
+        return delete(uri, null);
+    }
+
+    @Override
+    public Observable<Response> delete(String uri, Map<String, String> headers) {
+        return request(Method.DELETE, headers, uri, (Body) null);
+    }
+
+
+    @Override
+    public Observable<Response> delete(Function<RequestBuilder, Request> builder) {
+        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.DELETE)));
+    }
+
+    @Override
+    public Observable<Response> get(String uri) {
+        return get(uri, null);
+    }
+
+    @Override
+    public Observable<Response> get(String uri, Map<String, String> headers) {
+        return request(Method.GET, headers, uri, (Body) null);
+    }
+
+
+    @Override
+    public Observable<Response> get(Function<RequestBuilder, Request> builder) {
+        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.GET)));
+    }
+
+    @Override
+    public Observable<Response> patch(String uri, Body body) {
+        return patch(uri, null, body);
+    }
+
+    @Override
+    public Observable<Response> patch(String uri, Value entity) {
+        return patch(uri, null, entity);
+    }
+
+    @Override
+    public Observable<Response> patch(String uri, Map<String, String> headers, Body body) {
+        return request(Method.PATCH, headers, uri, body);
+    }
+
+    @Override
+    public Observable<Response> patch(String uri, Map<String, String> headers, Value entity) {
+        return request(Method.PATCH, headers, uri, entity);
+    }
+
+    @Override
+    public Observable<Response> patch(Function<RequestBuilder, Request> builder) {
+        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.PATCH)));
+    }
+
+    @Override
+    public Observable<Response> post(String uri, Body body) {
+        return post(uri, null, body);
+    }
+
+    @Override
+    public Observable<Response> post(String uri, Value entity) {
+        return post(uri, null, entity);
+    }
+
+    @Override
+    public Observable<Response> post(String uri, Map<String, String> headers, Body body) {
+        return request(Method.POST, headers, uri, body);
+    }
+
+    @Override
+    public Observable<Response> post(String uri, Map<String, String> headers, Value entity) {
+        return request(Method.POST, headers, uri, entity);
+    }
+
+    @Override
+    public Observable<Response> post(Function<RequestBuilder, Request> builder) {
+        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.POST)));
+    }
+
+    @Override
+    public Observable<Response> put(String uri, Body body) {
+        return put(uri, null, body);
+    }
+
+    @Override
+    public Observable<Response> put(String uri, Value entity) {
+        return put(uri, null, entity);
+    }
+
+    @Override
+    public Observable<Response> put(String uri, Map<String, String> headers, Body body) {
+        return request(Method.PUT, headers, uri, body);
+    }
+
+    @Override
+    public Observable<Response> put(String uri, Map<String, String> headers, Value entity) {
+        return request(Method.PUT, headers, uri, entity);
+    }
+
+    @Override
+    public Observable<Response> put(Function<RequestBuilder, Request> builder) {
+        return request(requestBuilder -> builder.apply(requestBuilder.method(Method.PUT)));
+    }
+}

--- a/core/src/main/java/foundation/stack/datamill/http/impl/EmptyBody.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/EmptyBody.java
@@ -39,4 +39,9 @@ public class EmptyBody implements Body {
     public Observable<String> asString() {
         return Observable.empty();
     }
+
+    @Override
+    public <T> Observable<T> fromJson(Class<T> clazz) {
+        return Observable.empty();
+    }
 }

--- a/core/src/main/java/foundation/stack/datamill/http/impl/MatcherBasedRoute.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/MatcherBasedRoute.java
@@ -3,7 +3,6 @@ package foundation.stack.datamill.http.impl;
 import com.google.common.base.Joiner;
 import foundation.stack.datamill.http.*;
 import rx.Observable;
-import rx.functions.Func1;
 import rx.functions.Func2;
 
 import java.util.ArrayList;

--- a/core/src/main/java/foundation/stack/datamill/http/impl/MethodAndUriMatcher.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/MethodAndUriMatcher.java
@@ -33,7 +33,8 @@ public class MethodAndUriMatcher extends RouteMatcher {
     public boolean matches(ServerRequest request) {
         boolean matches = matchesMethod(request) && matchesUri(request);
         if (matches) {
-            logger.debug("Request matched {} {}", method, uriTemplate == null ? "*" : uriTemplate);
+            logger.debug("Request matched {} {}",
+                    method != null ? method : "<* method>", uriTemplate == null ? "*" : uriTemplate);
         }
 
         return matches;

--- a/core/src/main/java/foundation/stack/datamill/http/impl/ResponseBuilderImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/ResponseBuilderImpl.java
@@ -77,6 +77,21 @@ public class ResponseBuilderImpl implements ResponseBuilder {
     }
 
     @Override
+    public Response status(Status status) {
+        return new ResponseImpl(status, headers, body);
+    }
+
+    @Override
+    public Response status(Status status, String content) {
+        return new ResponseImpl(status, headers, new ValueBody(new StringValue(content)));
+    }
+
+    @Override
+    public Response status(Status status, byte[] content) {
+        return new ResponseImpl(status, headers, new BytesBody(content));
+    }
+
+    @Override
     public ResponseBuilder streamingBodyAsBufferChunks(Func1<Observer<ByteBuffer>, Observable<ByteBuffer>> bodyStreamer) {
         Observable<ByteBuffer> chunkStream = Observable.fromEmitter(emitter -> {
             Subscription subscription = bodyStreamer.call(new PassthroughObserver<>(emitter))

--- a/core/src/main/java/foundation/stack/datamill/http/impl/RouteBuilderImpl.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/RouteBuilderImpl.java
@@ -8,6 +8,7 @@ import foundation.stack.datamill.http.builder.ElseBuilder;
 import foundation.stack.datamill.http.builder.RouteBuilder;
 import foundation.stack.datamill.reflection.Method;
 import foundation.stack.datamill.reflection.Bean;
+import foundation.stack.datamill.reflection.OutlineBuilder;
 import rx.Observable;
 
 import java.util.ArrayList;
@@ -19,6 +20,11 @@ import java.util.function.BiFunction;
  */
 public class RouteBuilderImpl implements RouteBuilder, ElseBuilder {
     private final List<Matcher> matchers = new ArrayList<>();
+
+    @Override
+    public <T> ElseBuilder elseIfMatchesBeanMethod(T bean) {
+        return elseIfMatchesBeanMethod(OutlineBuilder.DEFAULT.wrap(bean));
+    }
 
     @Override
     public ElseBuilder elseIfMatchesBeanMethod(Bean<?> bean) {
@@ -43,6 +49,11 @@ public class RouteBuilderImpl implements RouteBuilder, ElseBuilder {
     @Override
     public ElseBuilder elseIfUriMatches(String pattern, Route route) {
         return ifUriMatches(pattern, route);
+    }
+
+    @Override
+    public <T> ElseBuilder ifMatchesBeanMethod(T bean) {
+        return ifMatchesBeanMethod(OutlineBuilder.DEFAULT.wrap(bean));
     }
 
     @Override

--- a/core/src/main/java/foundation/stack/datamill/http/impl/UrlEncodedFormBody.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/UrlEncodedFormBody.java
@@ -1,0 +1,32 @@
+package foundation.stack.datamill.http.impl;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public class UrlEncodedFormBody extends BytesBody {
+    private static List<NameValuePair> toNameValuePairs(Map<String, String> map) {
+        if (map != null) {
+            ArrayList<NameValuePair> pairs = new ArrayList<>();
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                pairs.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+            }
+
+            return pairs;
+        }
+
+        return null;
+    }
+
+    public UrlEncodedFormBody(Map<String, String> parameters, Charset charset) {
+        super(URLEncodedUtils.format(toNameValuePairs(parameters), charset).getBytes(charset));
+    }
+}

--- a/core/src/main/java/foundation/stack/datamill/http/impl/UrlEncodedFormBody.java
+++ b/core/src/main/java/foundation/stack/datamill/http/impl/UrlEncodedFormBody.java
@@ -6,6 +6,7 @@ import org.apache.http.message.BasicNameValuePair;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ public class UrlEncodedFormBody extends BytesBody {
             return pairs;
         }
 
-        return null;
+        return Collections.emptyList();
     }
 
     public UrlEncodedFormBody(Map<String, String> parameters, Charset charset) {

--- a/core/src/test/java/foundation/stack/datamill/http/ClientImplTest.java
+++ b/core/src/test/java/foundation/stack/datamill/http/ClientImplTest.java
@@ -2,6 +2,7 @@ package foundation.stack.datamill.http;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
+import foundation.stack.datamill.http.impl.ClientImpl;
 import foundation.stack.datamill.http.impl.ValueBody;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -27,8 +28,8 @@ import static org.mockito.Mockito.*;
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
  */
-public class ClientTest {
-    private void verifyConnectionSetup(TestClient client, Method method, String uri, Map<String, String> headers, String entity)
+public class ClientImplTest {
+    private void verifyConnectionSetup(TestClientImpl client, Method method, String uri, Map<String, String> headers, String entity)
             throws Exception {
         HttpUriRequest request = client.getRequest();
 
@@ -47,13 +48,13 @@ public class ClientTest {
         }
     }
 
-    private void verifyConnectionSetup(TestClient client, Method method, String uri, Map<String, String> headers)
+    private void verifyConnectionSetup(TestClientImpl client, Method method, String uri, Map<String, String> headers)
             throws Exception {
         verifyConnectionSetup(client, method, uri, headers, null);
     }
 
-    private TestClient createClientAndRequest(Function<TestClient, Observable<Response>> requestor) {
-        TestClient client = new TestClient();
+    private TestClientImpl createClientAndRequest(Function<TestClientImpl, Observable<Response>> requestor) {
+        TestClientImpl client = new TestClientImpl();
         requestor.apply(client).toBlocking().last();
         return client;
     }
@@ -206,11 +207,11 @@ public class ClientTest {
                         "Accept", "application/json"), "test");
     }
 
-    private class TestClient extends Client {
+    private class TestClientImpl extends ClientImpl {
         private PipedOutputStream spiedPipedOutputStream;
         private HttpUriRequest request;
 
-        public TestClient() {
+        public TestClientImpl() {
         }
 
 

--- a/core/src/test/java/foundation/stack/datamill/http/impl/ResponseBuilderTest.java
+++ b/core/src/test/java/foundation/stack/datamill/http/impl/ResponseBuilderTest.java
@@ -8,9 +8,6 @@ import org.json.JSONArray;
 import org.junit.Test;
 import rx.Observable;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -39,6 +36,9 @@ public class ResponseBuilderTest {
         assertEquals("Content", builder.forbidden("Content").body().get().asString().toBlocking().last());
         assertEquals(Status.CONFLICT, builder.conflict("Content").status());
         assertEquals("Content", builder.conflict("Content").body().get().asString().toBlocking().last());
+        assertEquals(Status.TEMPORARY_REDIRECT, builder.status(Status.TEMPORARY_REDIRECT).status());
+        assertEquals(Status.TEMPORARY_REDIRECT, builder.status(Status.TEMPORARY_REDIRECT, "Content").status());
+        assertEquals("Content", builder.status(Status.TEMPORARY_REDIRECT, "Content").body().get().asString().toBlocking().last());
     }
 
     @Test

--- a/core/src/test/java/foundation/stack/datamill/http/impl/ServerRequestImplTest.java
+++ b/core/src/test/java/foundation/stack/datamill/http/impl/ServerRequestImplTest.java
@@ -1,8 +1,8 @@
 package foundation.stack.datamill.http.impl;
 
-import com.github.davidmoten.rx.Obs;
 import com.google.common.collect.ImmutableMultimap;
 import foundation.stack.datamill.http.Method;
+import foundation.stack.datamill.http.ServerRequest;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
@@ -12,6 +12,7 @@ import rx.Observable;
 import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Ravi Chodavarapu (rchodava@gmail.com)
@@ -29,6 +30,14 @@ public class ServerRequestImplTest {
         assertEquals(null, request.firstHeader("header3"));
         assertEquals("value1", request.firstQueryParameter("param1").asString());
         assertEquals("value2", request.firstQueryParameter("param2").asString());
+    }
+
+    @Test
+    public void headerAndQueryMapsAreNonNull() {
+        ServerRequest request = new ServerRequestImpl(
+                "GET", null, "/test", null, Charset.defaultCharset(), null);
+        assertNotNull(request.headers());
+        assertNotNull(request.queryParameters());
     }
 
     @Test

--- a/cucumber/src/main/java/foundation/stack/datamill/cucumber/HttpClient.java
+++ b/cucumber/src/main/java/foundation/stack/datamill/cucumber/HttpClient.java
@@ -1,6 +1,7 @@
 package foundation.stack.datamill.cucumber;
 
 import foundation.stack.datamill.http.Client;
+import foundation.stack.datamill.http.impl.ClientImpl;
 import foundation.stack.datamill.http.Method;
 import foundation.stack.datamill.http.Response;
 import foundation.stack.datamill.values.StringValue;
@@ -16,7 +17,7 @@ import java.util.Map;
 public class HttpClient {
     private final static Logger logger = LoggerFactory.getLogger(HttpClient.class);
 
-    private final Client client = new Client();
+    private final Client client = new ClientImpl();
 
     public Observable<Response> request(Method method, String uri, Map<String, String> headers, String payload) {
         logger.debug("Making a {} request to {} with headers {} and payload {}", method, uri, headers, payload);

--- a/lambda-api/pom.xml
+++ b/lambda-api/pom.xml
@@ -48,5 +48,9 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/lambda-api/pom.xml
+++ b/lambda-api/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>foundation.stack.datamill</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.1.1-SNAPSHOT</version>
+        <relativePath>../parent</relativePath>
+    </parent>
+
+    <artifactId>lambda-api</artifactId>
+    <packaging>jar</packaging>
+
+    <name>datamill Lambda-based API Gateway Support</name>
+    <url>https://github.com/rchodava/datamill</url>
+    <description>A bridge to use datamill to create Lambda-based API Gateway request handlers</description>
+
+    <properties>
+        <aws-lambda-java-log4j.version>1.0.0</aws-lambda-java-log4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>foundation.stack.datamill</groupId>
+            <artifactId>core</artifactId>
+            <version>0.1.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-log4j</artifactId>
+            <version>${aws-lambda-java-log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/lambda-api/src/main/java/foundation/stack/lambda/ApiHandler.java
+++ b/lambda-api/src/main/java/foundation/stack/lambda/ApiHandler.java
@@ -1,0 +1,233 @@
+package foundation.stack.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.google.common.base.Charsets;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import foundation.stack.datamill.http.*;
+import foundation.stack.datamill.http.builder.RouteBuilder;
+import foundation.stack.datamill.http.impl.RouteBuilderImpl;
+import foundation.stack.datamill.http.impl.ServerRequestImpl;
+import foundation.stack.datamill.http.impl.ValueBody;
+import foundation.stack.datamill.values.StringValue;
+import org.apache.log4j.Level;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public abstract class ApiHandler {
+    private static final String BODY_PROPERTY = "body";
+    private static final String LOG_LEVEL_PROPERTY = "logLevel";
+    private static final String HEADERS_PROPERTY = "headers";
+    private static final String HTTP_METHOD_PROPERTY = "httpMethod";
+    private static final String PATH_PROPERTY = "path";
+    private static final String QUERY_PARAMETERS_PROPERTY = "queryStringParameters";
+    private static final String STATUS_CODE = "statusCode";
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiHandler.class);
+
+    private static JSONObject badRequest() {
+        return buildResponse(Status.BAD_REQUEST.getCode());
+    }
+
+    private static ServerRequest buildRequest(
+            String method,
+            String path,
+            Multimap<String, String> headers,
+            Multimap<String, String> queryParameters,
+            String body) {
+        return new ServerRequestImpl(method, headers, path, queryParameters, Charsets.UTF_8,
+                body != null ? new ValueBody(new StringValue(body)) : null);
+    }
+
+    private static JSONObject internalServerError() {
+        return buildResponse(Status.INTERNAL_SERVER_ERROR.getCode());
+    }
+
+    private static JSONObject buildResponse(int statusCode) {
+        JSONObject json = new JSONObject();
+        json.put(STATUS_CODE, statusCode);
+        return json;
+    }
+
+    private static JSONObject notFound() {
+        return buildResponse(Status.NOT_FOUND.getCode());
+    }
+
+    private static void setLogLevel() {
+        String logLevelValue = System.getenv(LOG_LEVEL_PROPERTY);
+        if (logLevelValue != null) {
+            logger.debug("Setting log level to {}", logLevelValue);
+            Level logLevel = Level.toLevel(logLevelValue);
+
+            org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+            if (rootLogger != null) {
+                rootLogger.setLevel(logLevel);
+            }
+        }
+    }
+
+    private static Multimap<String, String> toStringMap(JSONObject object) {
+        if (object != null) {
+            Multimap<String, String> map = HashMultimap.create();
+            Iterator<String> keys = object.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                if (key != null) {
+                    map.put(key, object.optString(key));
+                }
+            }
+
+            return map;
+        }
+
+        return null;
+    }
+
+    private static JSONObject toJson(Multimap<String, String> headers) {
+        if (headers != null && headers.size() > 0) {
+            JSONObject json = new JSONObject();
+            for (Map.Entry<String, String> entry : headers.entries()) {
+                json.put(entry.getKey(), entry.getValue());
+            }
+
+            return json;
+        }
+
+        return null;
+    }
+
+    private static JSONObject transformResponse(Response response) {
+        if (response != null) {
+            Status status = response.status();
+            if (status != null) {
+                int statusCode = status.getCode();
+                JSONObject json = buildResponse(statusCode);
+
+                JSONObject headers = toJson(response.headers());
+                json.put(HEADERS_PROPERTY, headers);
+
+                Optional<Body> body = response.body();
+                if (body != null && body.isPresent()) {
+                    body.get().asString().subscribe(bodyContent -> json.put(BODY_PROPERTY, bodyContent));
+                }
+
+                return json;
+            }
+
+            logger.debug("Application returned a response with no status code!");
+            return internalServerError();
+        }
+
+        return notFound();
+    }
+
+    private static void transformErrorResponse(
+            Throwable originalError,
+            Observable<Response> handledResponse,
+            JSONObject[] responseJson) {
+        if (handledResponse != null) {
+            logger.debug("Error occurred: {} - invoking application error handler", originalError.getMessage());
+            handledResponse.subscribe(
+                    response -> responseJson[0] = transformResponse(response),
+                    ___ -> responseJson[0] = internalServerError());
+        } else {
+            logger.debug("No application error handler to handle error", originalError);
+            responseJson[0] = internalServerError();
+        }
+    }
+
+    private static void write(OutputStream outputStream, JSONObject json) {
+        logger.debug("Returning {} response", json.get(STATUS_CODE));
+        if (logger.isTraceEnabled()) {
+            logger.trace("Response: {}", json);
+        }
+
+        try (OutputStreamWriter writer = new OutputStreamWriter(outputStream, Charsets.UTF_8)) {
+            json.write(writer);
+        } catch (IOException e) {
+            logger.debug("Error while closing output response");
+        }
+    }
+
+    protected abstract Route constructRoute(RouteBuilder builder);
+
+    public final void handle(InputStream requestStream, OutputStream responseStream, Context __) {
+        setLogLevel();
+
+        ServerRequest request = null;
+        JSONObject[] responseJson = new JSONObject[]{null};
+        try {
+            JSONObject json = new JSONObject(new JSONTokener(requestStream));
+
+            String path = json.optString(PATH_PROPERTY);
+            Multimap<String, String> headers = toStringMap(json.optJSONObject(HEADERS_PROPERTY));
+            Multimap<String, String> queryParameters = toStringMap(json.optJSONObject(QUERY_PARAMETERS_PROPERTY));
+            String method = json.optString(HTTP_METHOD_PROPERTY);
+            String body = json.optString(BODY_PROPERTY);
+
+            if (method != null) {
+                logger.debug("{} {} request received", method, path);
+
+                Route route = constructRoute(new RouteBuilderImpl());
+                request = buildRequest(method, path, headers, queryParameters, body);
+
+                Observable<Response> responseObservable = route.apply(request);
+                if (responseObservable != null) {
+                    ServerRequest pinnedRequest = request;
+                    responseObservable.subscribe(
+                            response -> responseJson[0] = transformResponse(response),
+                            error -> handleError(pinnedRequest, error, responseJson));
+
+                    if (responseJson[0] == null) {
+                        responseJson[0] = notFound();
+                    }
+
+                    write(responseStream, responseJson[0]);
+                } else {
+                    write(responseStream, notFound());
+                }
+            } else {
+                logger.debug("Received request with no HTTP method!");
+                write(responseStream, badRequest());
+            }
+        } catch (Exception e) {
+            logger.debug("Error occurred: {} - invoking error handler", e.getMessage());
+            handleError(request, e, responseJson);
+            write(responseStream, responseJson[0]);
+        }
+    }
+
+    protected Observable<Response> handleError(Throwable error) {
+        return null;
+    }
+
+    protected Observable<Response> handleError(ServerRequest request, Throwable error) {
+        return null;
+    }
+
+    private void handleError(ServerRequest request, Throwable error, JSONObject[] responseJson) {
+        Observable<Response> errorObservable;
+
+        if (request != null) {
+            errorObservable = handleError(request, error);
+        } else {
+            errorObservable = handleError(error);
+        }
+
+        transformErrorResponse(error, errorObservable, responseJson);
+    }
+}

--- a/lambda-api/src/test/java/foundation/stack/lambda/ApiHandlerTest.java
+++ b/lambda-api/src/test/java/foundation/stack/lambda/ApiHandlerTest.java
@@ -1,0 +1,149 @@
+package foundation.stack.lambda;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Multimap;
+import foundation.stack.datamill.http.Response;
+import foundation.stack.datamill.http.Route;
+import foundation.stack.datamill.http.ServerRequest;
+import foundation.stack.datamill.http.builder.RouteBuilder;
+import org.json.JSONObject;
+import org.junit.Test;
+import rx.Observable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Ravi Chodavarapu (rchodava@gmail.com)
+ */
+public class ApiHandlerTest {
+    private static String toString(Multimap<String, String> map) {
+        if (map != null) {
+            StringBuilder builder = new StringBuilder("(");
+            for (Map.Entry<String, String> entry : map.entries()) {
+                builder.append(entry.getKey());
+                builder.append("=");
+                builder.append(entry.getValue());
+                builder.append(',');
+            }
+            builder.append(")");
+
+            return builder.toString();
+        }
+
+        return "()";
+    }
+
+    private static class TestApiHandler extends ApiHandler {
+        @Override
+        protected Route constructRoute(RouteBuilder builder) {
+            return builder.ifUriMatches("/test",
+                    request -> request.respond(b ->
+                            b.header("Location", "http://localhost")
+                                    .ok(request.method() + " " + request.uri() + " " +
+                                    ApiHandlerTest.toString(request.headers()) + " " +
+                                    ApiHandlerTest.toString(request.queryParameters()))))
+                    .elseIfUriMatches("/null", request -> Observable.just(null))
+                    .elseIfUriMatches("/error", request -> Observable.error(new IllegalArgumentException()))
+                    .elseIfUriMatches("/handled", request -> Observable.error(new IllegalStateException()))
+                    .elseIfUriMatches("/unhandled", request -> {
+                        throw new IllegalStateException();
+                    })
+                    .orElse(request -> request.respond(b -> b.ok("else")));
+        }
+
+        @Override
+        protected Observable<Response> handleError(ServerRequest request, Throwable error) {
+            if (error instanceof IllegalStateException) {
+                return request.respond(b -> b.ok("handled"));
+            }
+
+            return null;
+        }
+    }
+
+    @Test
+    public void handle() {
+        // Test valid request
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TestApiHandler handler = new TestApiHandler();
+        handler.handle(new ByteArrayInputStream(("{" +
+                "\"path\": \"/test\", " +
+                "\"httpMethod\": \"GET\", " +
+                "\"headers\": {" +
+                "\"Authorization\": \"token\", " +
+                "\"Accept\": \"application/json\"" +
+                "}," +
+                "\"queryStringParameters\": {" +
+                "\"param1\": \"value1\", " +
+                "\"param2\": \"value2\"" +
+                "}" +
+                "}")
+                .getBytes(Charsets.UTF_8)), output, null);
+
+        JSONObject response = new JSONObject(new String(output.toByteArray(), Charsets.UTF_8));
+        assertEquals(200, response.optInt("statusCode"));
+        assertEquals("GET /test (Authorization=token,Accept=application/json,) (param1=value1,param2=value2,)",
+                response.optString("body"));
+        assertEquals("http://localhost", response.optJSONObject("headers").optString("Location"));
+
+        // Request with no HTTP method
+        output = new ByteArrayOutputStream();
+        handler.handle(new ByteArrayInputStream(("{ \"path\": \"/test\" }").getBytes(Charsets.UTF_8)), output, null);
+
+        response = new JSONObject(new String(output.toByteArray(), Charsets.UTF_8));
+        assertEquals(400, response.optInt("statusCode"));
+        assertEquals("", response.optString("body"));
+
+        // Test a route that returns a null response
+        output = new ByteArrayOutputStream();
+        handler.handle(new ByteArrayInputStream(("{" +
+                "\"path\": \"/null\", " +
+                "\"httpMethod\": \"GET\"" +
+                "}")
+                .getBytes(Charsets.UTF_8)), output, null);
+
+        response = new JSONObject(new String(output.toByteArray(), Charsets.UTF_8));
+        assertEquals(404, response.optInt("statusCode"));
+        assertEquals("", response.optString("body"));
+
+        // Test a request with an uknown path
+        output = new ByteArrayOutputStream();
+        handler.handle(new ByteArrayInputStream(("{" +
+                "\"path\": \"/other\", " +
+                "\"httpMethod\": \"GET\"" +
+                "}")
+                .getBytes(Charsets.UTF_8)), output, null);
+
+        response = new JSONObject(new String(output.toByteArray(), Charsets.UTF_8));
+        assertEquals(200, response.optInt("statusCode"));
+        assertEquals("else", response.optString("body"));
+
+        // Test a route that results in an error being emitted, that isn't handled
+        output = new ByteArrayOutputStream();
+        handler.handle(new ByteArrayInputStream(("{" +
+                "\"path\": \"/error\", " +
+                "\"httpMethod\": \"GET\"" +
+                "}")
+                .getBytes(Charsets.UTF_8)), output, null);
+
+        response = new JSONObject(new String(output.toByteArray(), Charsets.UTF_8));
+        assertEquals(500, response.optInt("statusCode"));
+        assertEquals("", response.optString("body"));
+
+        // Test a route that results in an error being thrown
+        output = new ByteArrayOutputStream();
+        handler.handle(new ByteArrayInputStream(("{" +
+                "\"path\": \"/unhandled\", " +
+                "\"httpMethod\": \"GET\"" +
+                "}")
+                .getBytes(Charsets.UTF_8)), output, null);
+
+        response = new JSONObject(new String(output.toByteArray(), Charsets.UTF_8));
+        assertEquals(500, response.optInt("statusCode"));
+        assertEquals("", response.optString("body"));
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,6 +74,11 @@
                 <version>1.7.16</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.16</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
                 <version>4.1.0.CR6</version>
@@ -205,7 +210,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>2.7.3</version>
-                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.7.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>19.0</version>
+                <version>21.0</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>
@@ -179,6 +179,21 @@
                 <version>3.1.7</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.7.3</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.7.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
                 <version>2.3.3</version>
@@ -200,21 +215,7 @@
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-rules</artifactId>
                 <version>1.16.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>4.5.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.7.3</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.7.3</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <module>parent</module>
         <module>core</module>
         <module>cucumber</module>
+        <module>lambda-api</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Allow bean method matching routes to be built with plain instances, which are wrapped by the API
Allow responses with any status codes to be built by the response builder
Add Jackson based deserialization directly to the body
Have client make the request with a plain Observable, which the consumer can then schedule on a Scheduler if they want
Add a URL-encoded form body for POSTing form data
Add support to create APIs based on AWS Lambda-backed API Gateway proxies